### PR TITLE
Filter on PathMonitor

### DIFF
--- a/src/ui/GenioWatchingFilter.h
+++ b/src/ui/GenioWatchingFilter.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023, Andrea Anzani <andrea.anzani@gmail.com>
+ * All rights reserved. Distributed under the terms of the MIT license.
+ */
+#ifndef GenioWatchingFilter_H
+#define GenioWatchingFilter_H
+
+
+#include <PathMonitor.h>
+#include "Log.h"
+
+class GenioWatchingFilter : public BPrivate::BPathMonitor::BWatchingInterface {
+public:
+
+	status_t WatchNode(const node_ref* node, uint32 flags, const BHandler* handler,
+							  		const BLooper* looper = NULL) 
+									
+	{
+		status_t status;
+		BDirectory dir(node);
+		if ((status = dir.InitCheck()) != B_OK) {
+			// Typically the reason for this failure is "Not a directory".
+			// As we want to avoid to use a watch_node for standard file,
+			// we quit here.
+			return B_OK;
+		}
+		
+		status = BPrivate::BPathMonitor::BWatchingInterface::WatchNode(node, flags, handler, looper);
+		if (status != B_OK) {
+			LogErrorF("Can't watch_node for node_id [%ld] (%s)", node->node, strerror(status));
+			//TODO: maybe we should notify the user that the PathMonitor is not working?
+		}
+		return status;
+								
+	}
+};
+
+#endif // GenioWatchingFilter_H

--- a/src/ui/GenioWatchingFilter.h
+++ b/src/ui/GenioWatchingFilter.h
@@ -9,6 +9,10 @@
 #include <PathMonitor.h>
 #include "Log.h"
 
+// This is attached to the PathMonitor class to avoid watching too many (useless) files.
+// In the ProjectFolderBrowser we care only on directories and related files events.
+// We can't use the B_WATCH_DIRECTORIES_ONLY flag as PathMonitor won't notify for file related events.
+
 class GenioWatchingFilter : public BPrivate::BPathMonitor::BWatchingInterface {
 public:
 
@@ -20,7 +24,7 @@ public:
 		BDirectory dir(node);
 		if ((status = dir.InitCheck()) != B_OK) {
 			// Typically the reason for this failure is "Not a directory".
-			// As we want to avoid to use a watch_node for standard file,
+			// As we want to avoid to use a watch_node for every standard file,
 			// we quit here.
 			return B_OK;
 		}

--- a/src/ui/GenioWatchingFilter.h
+++ b/src/ui/GenioWatchingFilter.h
@@ -15,7 +15,6 @@
 
 class GenioWatchingFilter : public BPrivate::BPathMonitor::BWatchingInterface {
 public:
-
 	status_t WatchNode(const node_ref* node, uint32 flags, const BHandler* handler,
 							  		const BLooper* looper = NULL) 
 									
@@ -35,7 +34,6 @@ public:
 			//TODO: maybe we should notify the user that the PathMonitor is not working?
 		}
 		return status;
-								
 	}
 };
 

--- a/src/ui/ProjectsFolderBrowser.cpp
+++ b/src/ui/ProjectsFolderBrowser.cpp
@@ -13,7 +13,6 @@
 #include <MenuItem.h>
 #include <Mime.h>
 #include <Path.h>
-#include <PathMonitor.h>
 #include <Window.h>
 #include <NaturalCompare.h>
 
@@ -27,6 +26,7 @@
 #include "ProjectItem.h"
 #include "TemplateManager.h"
 #include "Utils.h"
+#include "GenioWatchingFilter.h"
 
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "ProjectsFolderBrowser"
@@ -71,11 +71,15 @@ ProjectsFolderBrowser::ProjectsFolderBrowser():
 	
 	SetInvocationMessage(new BMessage(MSG_PROJECT_MENU_OPEN_FILE));
 	
+	fGenioWatchingFilter = new GenioWatchingFilter();
+	BPrivate::BPathMonitor::SetWatchingInterface(fGenioWatchingFilter);
 }
 
  
 ProjectsFolderBrowser::~ProjectsFolderBrowser()
 {
+	BPrivate::BPathMonitor::SetWatchingInterface(nullptr);
+	delete fGenioWatchingFilter;
 	delete fProjectMenu;
 }
 

--- a/src/ui/ProjectsFolderBrowser.h
+++ b/src/ui/ProjectsFolderBrowser.h
@@ -26,6 +26,7 @@ enum {
 
 class ProjectFolder;
 class ProjectItem;
+class GenioWatchingFilter;
 
 class ProjectsFolderBrowser : public BOutlineListView {
 public:
@@ -80,6 +81,7 @@ private:
 	BMenuItem*			fShowInTrackerProjectMenuItem;
 	BMenuItem*			fOpenTerminalProjectMenuItem;
 	bool				fIsBuilding = false;
+	GenioWatchingFilter* fGenioWatchingFilter;
 	
 };
 


### PR DESCRIPTION
This filter avoids to do a watch_node on every single file in the ProjectFolderBrowser.