### PR TITLE
Minor string tweaks

### DIFF
--- a/src/GenioApp.cpp
+++ b/src/GenioApp.cpp
@@ -56,13 +56,13 @@ GenioApp::AboutRequested()
 	BString extraInfo;
 	extraInfo << B_TRANSLATE("Genio is a fork of Ideam and available under the MIT license.");
 	extraInfo << "\nIdeam (c) 2017 A. Mosca\n\n";
-	extraInfo << GenioNames::kApplicationName << " " << B_TRANSLATE("uses:");
-	extraInfo << "\nScintilla lib";
-	extraInfo << "\nCopyright 1998-2003 by Neil Hodgson <neilh@scintilla.org>";
-	extraInfo << "\n\nScintilla for Haiku";
-	extraInfo << "\nCopyright 2011 by Andrea Anzani <andrea.anzani@gmail.com>";
-	extraInfo << "\nCopyright 2014-2015 by Kacper Kasper <kacperkasper@gmail.com>\n\n";
-	extraInfo << B_TRANSLATE("See Credits for a complete list.\n\n");
+	extraInfo << B_TRANSLATE("Genio uses:"
+		"\nScintilla lib"
+		"\nCopyright 1998-2003 by Neil Hodgson <neilh@scintilla.org>"
+		"\n\nScintilla for Haiku"
+		"\nCopyright 2011 by Andrea Anzani <andrea.anzani@gmail.com>"
+		"\nCopyright 2014-2015 by Kacper Kasper <kacperkasper@gmail.com>\n\n");
+	extraInfo << B_TRANSLATE("See credits for a complete list.\n\n");
 	extraInfo << B_TRANSLATE("Made with love in Italy");
 
 	window->AddExtraInfo(extraInfo);
@@ -167,12 +167,12 @@ GenioApp::_CheckSettingsVersion()
 	// Settings file missing or corrupted
 	if (fileVersion.IsEmpty() || fileVersion == "0.0.0.0") {
 		BString text;
-		text << B_TRANSLATE("Settings file is corrupted or deleted,")
+		text << B_TRANSLATE("The settings file doesn't exist or is corrupted.")
 			 << "\n"
-			 << B_TRANSLATE("do You want to ignore, review or load to defaults?");
+			 << B_TRANSLATE("Do you want to ignore, review or load defaults?");
 
 		BAlert* alert = new BAlert("SettingsDeletedDialog", text,
-			B_TRANSLATE("Ignore"), B_TRANSLATE("Review"), B_TRANSLATE("Load"),
+			B_TRANSLATE("Ignore"), B_TRANSLATE("Review"), B_TRANSLATE("Load defaults"),
 			B_WIDTH_AS_USUAL, B_OFFSET_SPACING, B_WARNING_ALERT);
 
 		alert->SetShortcut(0, B_ESCAPE);
@@ -195,12 +195,12 @@ GenioApp::_CheckSettingsVersion()
 		// App version > file version
 		if (result > 0) {
 			BString text;
-			text << B_TRANSLATE("Settings file for a previous version detected,")
+			text << B_TRANSLATE("Settings file for a previous version detected.")
 				 << "\n"
-				 << B_TRANSLATE("do You want to ignore, review or load to defaults?");
+				 << B_TRANSLATE("Do you want to ignore, review or load defaults?");
 
 			BAlert* alert = new BAlert("SettingsUpdateDialog", text,
-				B_TRANSLATE("Ignore"), B_TRANSLATE("Review"), B_TRANSLATE("Load"),
+				B_TRANSLATE("Ignore"), B_TRANSLATE("Review"), B_TRANSLATE("Load defaults"),
 				B_WIDTH_AS_USUAL, B_OFFSET_SPACING, B_WARNING_ALERT);
 
 			alert->SetShortcut(0, B_ESCAPE);

--- a/src/project/ProjectSettingsWindow.cpp
+++ b/src/project/ProjectSettingsWindow.cpp
@@ -24,7 +24,7 @@ enum
 {
 	MSG_DEFAULTS_CLICKED			= 'defs',
 	MSG_CANCEL_CLICKED				= 'canc',
-	MSG_SAVE_CLICKED				= 'save',
+	MSG_OK_CLICKED					= 'okay',
 	MSG_BUILD_MODE_SELECTED			= 'bmse',
 };
 
@@ -69,7 +69,7 @@ ProjectSettingsWindow::MessageReceived(BMessage *msg)
 			PostMessage(B_QUIT_REQUESTED);
 			break;
 		}
-		case MSG_SAVE_CLICKED: {
+		case MSG_OK_CLICKED: {
 			_CloseProject();
 			PostMessage(B_QUIT_REQUESTED);
 			break;
@@ -145,7 +145,7 @@ ProjectSettingsWindow::_InitWindow()
 	
 	// "Source Control" Box
 	fSourceControlBox = new BBox("SourceControlBox");
-	fSourceControlBox->SetLabel(B_TRANSLATE("Source Control"));
+	fSourceControlBox->SetLabel(B_TRANSLATE("Source control"));
 
 	BLayoutBuilder::Grid<>(fSourceControlBox)
 	.SetInsets(10.0f, 24.0f, 10.0f, 10.0f)
@@ -171,8 +171,8 @@ ProjectSettingsWindow::_InitWindow()
 		B_TRANSLATE("Default"), new BMessage(MSG_DEFAULTS_CLICKED));
 	BButton* cancelButton = new BButton("cancel",
 		B_TRANSLATE("Cancel"), new BMessage(MSG_CANCEL_CLICKED));
-	BButton* saveButton = new BButton("save",
-		B_TRANSLATE("Save"), new BMessage(MSG_SAVE_CLICKED));
+	BButton* saveButton = new BButton("ok",
+		B_TRANSLATE("OK"), new BMessage(MSG_OK_CLICKED));
 
 	// Window layout
 	BLayoutBuilder::Group<>(this, B_VERTICAL, B_USE_DEFAULT_SPACING)

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -1551,7 +1551,7 @@ GenioWindow::_FileSave(int32 index)
 
 	// Readonly file, should not happen
 	if (editor->IsReadOnly()) {
-		notification << (B_TRANSLATE("File is Read-only"));
+		notification << (B_TRANSLATE("File is read-only"));
 		_SendNotification(notification, "FILE_ERR");
 		return B_ERROR;
 	}
@@ -1874,9 +1874,9 @@ GenioWindow::_HandleExternalMoveModification(entry_ref* oldRef, entry_ref* newRe
 
 	BString text;
 	text << GenioNames::kApplicationName << ":\n";
-	text << B_TRANSLATE("File \"%file%\" was moved externally,")
+	text << B_TRANSLATE("File \"%file%\" was moved externally.")
 		 << "\n"
-		 << B_TRANSLATE("do You want to ignore, close or reload it?");
+		 << B_TRANSLATE("Do you want to ignore, close or reload it?");
 
 	text.ReplaceAll("%file%", oldRef->name);
 
@@ -1939,11 +1939,11 @@ GenioWindow::_HandleExternalRemoveModification(int32 index)
 
 	BString text;
 	text << GenioNames::kApplicationName << ":\n";
-	text 	<< B_TRANSLATE("File \"%file%\" was removed externally,")
+	text 	<< B_TRANSLATE("File \"%file%\" was removed externally.")
 			<< "\n"
-			<< B_TRANSLATE("do You want to keep the file or discard it?")
+			<< B_TRANSLATE("Do you want to keep the file or discard it?")
 			<< "\n"
-			<< B_TRANSLATE("If kept and modified save it or it will be lost");
+			<< B_TRANSLATE("If kept and modified, save it or it will be lost");
 
 	text.ReplaceAll("%file%", fileName);
 
@@ -2257,7 +2257,7 @@ GenioWindow::_InitActions()
 
 	ActionManager::RegisterAction(MSG_FILE_SAVE, 
 								   B_TRANSLATE("Save"), 
-								   B_TRANSLATE("Save current File"), 
+								   B_TRANSLATE("Save current file"), 
 								   "kIconSave", 'S');
 								   
 	ActionManager::RegisterAction(MSG_FILE_SAVE_AS,
@@ -2266,13 +2266,13 @@ GenioWindow::_InitActions()
 
 	ActionManager::RegisterAction(MSG_FILE_SAVE_ALL,
 								   B_TRANSLATE("Save all"),
-								   B_TRANSLATE("Save all Files"), 
+								   B_TRANSLATE("Save all files"), 
 								   "kIconSaveAll", 'S', B_SHIFT_KEY);
 
 	
 	ActionManager::RegisterAction(MSG_FILE_CLOSE,
 								   B_TRANSLATE("Close"),
-								   B_TRANSLATE("Close File"), 
+								   B_TRANSLATE("Close file"), 
 								   "kIconClose", 'W'); 
 	
 	ActionManager::RegisterAction(MSG_FILE_CLOSE_ALL,
@@ -2308,7 +2308,7 @@ GenioWindow::_InitActions()
 								   "", "", B_INSERT);
 	ActionManager::RegisterAction(MSG_FILE_FOLD_TOGGLE,
 								   B_TRANSLATE("Fold/Unfold all"),
-								   B_TRANSLATE("Fold/unfold all"),
+								   B_TRANSLATE("Fold/Unfold all"),
 								   "App_OpenTargetFolder");
 	ActionManager::RegisterAction(MSG_WHITE_SPACES_TOGGLE,
 								   B_TRANSLATE("Toggle white spaces"),
@@ -2329,7 +2329,7 @@ GenioWindow::_InitActions()
 								   "", "", 'C', B_SHIFT_KEY);
 								   
 	ActionManager::RegisterAction(MSG_AUTOCOMPLETION, 
-								   B_TRANSLATE("Autocompletion"), "","", B_SPACE);
+								   B_TRANSLATE("Autocomplete"), "","", B_SPACE);
 								   
 	ActionManager::RegisterAction(MSG_FORMAT, 
 								   B_TRANSLATE("Format"));
@@ -2344,7 +2344,7 @@ GenioWindow::_InitActions()
 								   B_TRANSLATE("Go to implementation"));
 								   
 	ActionManager::RegisterAction(MSG_SWITCHSOURCE, 
-								   B_TRANSLATE("Switch source header"), "", "", B_TAB);
+								   B_TRANSLATE("Switch source/header"), "", "", B_TAB);
 								   
 	ActionManager::RegisterAction(MSG_SIGNATUREHELP,
 								   B_TRANSLATE("Signature help"), "", "", '?');
@@ -2352,7 +2352,7 @@ GenioWindow::_InitActions()
 
 	ActionManager::RegisterAction(MSG_VIEW_ZOOMIN,  B_TRANSLATE("Zoom in"), "", "", '+');
 	ActionManager::RegisterAction(MSG_VIEW_ZOOMOUT, B_TRANSLATE("Zoom out"), "", "", '-');
-	ActionManager::RegisterAction(MSG_VIEW_ZOOMRESET, B_TRANSLATE("Zoom reset"), "", "", '0');
+	ActionManager::RegisterAction(MSG_VIEW_ZOOMRESET, B_TRANSLATE("Reset zoom"), "", "", '0');
 
 
 	ActionManager::RegisterAction(MSG_FIND_GROUP_TOGGLED, //MSG_FIND_GROUP_SHOW,
@@ -2404,7 +2404,7 @@ GenioWindow::_InitActions()
 								   "kIconTerminal");
 								   
 	ActionManager::RegisterAction(MSG_TOGGLE_TOOLBAR,
-								   B_TRANSLATE("Show toolBar"));
+								   B_TRANSLATE("Show toolbar"));
 								   
 	
 	ActionManager::RegisterAction(MSG_BUILD_PROJECT,
@@ -2430,10 +2430,10 @@ GenioWindow::_InitActions()
 								  B_TRANSLATE("Set buffer read-only"), "kIconUnlocked");
 								  
 	ActionManager::RegisterAction(MSG_FILE_PREVIOUS_SELECTED, "",
-						          B_TRANSLATE("Select previous File"), "kIconBack_1");
+						          B_TRANSLATE("Select previous file"), "kIconBack_1");
 								  
 	ActionManager::RegisterAction(MSG_FILE_NEXT_SELECTED, "", 
-								  B_TRANSLATE("Select next File"), "kIconForward_2");
+								  B_TRANSLATE("Select next file"), "kIconForward_2");
 								   
 	// Find Panel
 	ActionManager::RegisterAction(MSG_FIND_NEXT,
@@ -2692,17 +2692,17 @@ GenioWindow::_InitMenu()
 
 	fGitMenu->AddSeparatorItem();
 
-	fGitMenu->AddItem(fGitLogOnelineItem = new BMenuItem(B_TRANSLATE("Log (Oneline)"), nullptr));
+	fGitMenu->AddItem(fGitLogOnelineItem = new BMenuItem(B_TRANSLATE("Log (oneline)"), nullptr));
 	BMessage* git_log_oneline_message = new BMessage(MSG_GIT_COMMAND);
 	git_log_oneline_message->AddString("command", "log --oneline --decorate");
 	fGitLogOnelineItem->SetMessage(git_log_oneline_message);
 
-	fGitMenu->AddItem(fGitPullRebaseItem = new BMenuItem(B_TRANSLATE("Pull (Rebase)"), nullptr));
+	fGitMenu->AddItem(fGitPullRebaseItem = new BMenuItem(B_TRANSLATE("Pull (rebase)"), nullptr));
 	BMessage* git_pull_rebase_message = new BMessage(MSG_GIT_COMMAND);
 	git_pull_rebase_message->AddString("command", "pull --rebase");
 	fGitPullRebaseItem->SetMessage(git_pull_rebase_message);
 
-	fGitMenu->AddItem(fGitStatusShortItem = new BMenuItem(B_TRANSLATE("Status (Short)"), nullptr));
+	fGitMenu->AddItem(fGitStatusShortItem = new BMenuItem(B_TRANSLATE("Status (short)"), nullptr));
 	BMessage* git_status_short_message = new BMessage(MSG_GIT_COMMAND);
 	git_status_short_message->AddString("command", "status --short");
 	fGitStatusShortItem->SetMessage(git_status_short_message);
@@ -2765,7 +2765,7 @@ GenioWindow::_InitToolbar()
 	
 	ActionManager::AddItem(MSG_FILE_CLOSE, fToolBar);
 	
-	fToolBar->AddAction(MSG_FILE_MENU_SHOW, B_TRANSLATE("Indexed File list"), "kIconFileList");
+	fToolBar->AddAction(MSG_FILE_MENU_SHOW, B_TRANSLATE("Indexed file list"), "kIconFileList");
 	
 	
 	ActionManager::SetEnabled(MSG_FIND_GROUP_TOGGLED, false);
@@ -2780,7 +2780,7 @@ GenioWindow::_InitOutputSplit()
 	
 	fProblemsPanel = new ProblemsPanel();
 
-	fBuildLogView = new ConsoleIOView(B_TRANSLATE("Build Log"), BMessenger(this));
+	fBuildLogView = new ConsoleIOView(B_TRANSLATE("Build log"), BMessenger(this));
 
 	fConsoleIOView = new ConsoleIOView(B_TRANSLATE("Console I/O"), BMessenger(this));
 
@@ -3421,7 +3421,7 @@ GenioWindow::_OpenTerminalWorkingDirectory()
 	if (returnStatus != B_OK)
 		notification << B_TRANSLATE("An error occurred while opening Terminal and setting working directory to:") << itemPath;
 	else
-		notification << B_TRANSLATE("Terminal succesfully opened with working directory:") << itemPath;
+		notification << B_TRANSLATE("Terminal successfully opened with working directory:") << itemPath;
 	_SendNotification(notification, "PROJ_TERM");
 	return returnStatus == 0 ? B_OK : errno;
 }

--- a/src/ui/SettingsWindow.cpp
+++ b/src/ui/SettingsWindow.cpp
@@ -49,7 +49,7 @@ enum {
 	MSG_BRACE_MATCHING_TOGGLED				= 'brma',
 	MSG_BUTTON_APPLY_CLICKED				= 'buap',
 	MSG_BUTTON_DEFAULT_CLICKED				= 'bude',
-	MSG_BUTTON_EXIT_CLICKED					= 'buex',
+	MSG_BUTTON_CANCEL_CLICKED				= 'bucl',
 	MSG_BUTTON_REVERT_CLICKED				= 'bure',
 	MSG_EDGE_LINE_COLUMN_CHANGED			= 'elco',
 	MSG_EDITOR_FONT_CHANGED					= 'edfo',
@@ -178,7 +178,7 @@ SettingsWindow::MessageReceived(BMessage *msg)
 
 			break;
 		}
-		case MSG_BUTTON_EXIT_CLICKED: {
+		case MSG_BUTTON_CANCEL_CLICKED: {
 			PostMessage(B_QUIT_REQUESTED);
 			break;
 		}
@@ -484,7 +484,7 @@ SettingsWindow::_InitWindow()
 	// Buttons
 	fRevertButton = new BButton(B_TRANSLATE("Revert"), new BMessage(MSG_BUTTON_REVERT_CLICKED));
 	fDefaultButton = new BButton(B_TRANSLATE("Default"), new BMessage(MSG_BUTTON_DEFAULT_CLICKED));
-	fExitButton = new BButton(B_TRANSLATE("Exit"), new BMessage(MSG_BUTTON_EXIT_CLICKED));
+	fExitButton = new BButton(B_TRANSLATE("Cancel"), new BMessage(MSG_BUTTON_CANCEL_CLICKED));
 	fApplyButton = new BButton(B_TRANSLATE("Apply"), new BMessage(MSG_BUTTON_APPLY_CLICKED));
 
 	fRevertButton->SetEnabled(false);
@@ -903,9 +903,9 @@ SettingsWindow::_PageEditorView()
 	}
 
 	fSyntaxHighlight = new BCheckBox("SyntaxHighlight",
-		B_TRANSLATE("Enable Syntax highlighting"), new BMessage(MSG_SYNTAX_HIGHLIGHT_TOGGLED));
+		B_TRANSLATE("Enable syntax highlighting"), new BMessage(MSG_SYNTAX_HIGHLIGHT_TOGGLED));
 	fBraceMatch = new BCheckBox("BraceMatch",
-		B_TRANSLATE("Enable Brace matching"), new BMessage(MSG_BRACE_MATCHING_TOGGLED));
+		B_TRANSLATE("Enable brace matching"), new BMessage(MSG_BRACE_MATCHING_TOGGLED));
 	fSaveCaret = new BCheckBox("SaveCaret",
 		B_TRANSLATE("Save caret position"), new BMessage(MSG_SAVE_CARET_TOGGLED));
 	fTabWidthSpinner = new BSpinner("TabWidth",
@@ -990,7 +990,7 @@ SettingsWindow::_PageGeneralView()
 
 	// Text Control
 	fProjectsDirectory = new BTextControl("ProjectsDirectory",
-		B_TRANSLATE("Projects directory:"), "", nullptr);
+		B_TRANSLATE("Projects folder:"), "", nullptr);
 	fProjectsDirectory->SetModificationMessage(new BMessage(MSG_PROJECT_DIRECTORY_EDITED));
 
 	// Button disabled now
@@ -1006,17 +1006,17 @@ SettingsWindow::_PageGeneralView()
 
 	// Check Box
 	fFullPathWindowTitle = new BCheckBox("FullPathWindowTitle",
-		B_TRANSLATE("File full path in window title"), new BMessage(MSG_FULL_PATH_TOGGLED));
+		B_TRANSLATE("Show full path in window title"), new BMessage(MSG_FULL_PATH_TOGGLED));
 
 	fLogDestination = new BOptionPopUp("LogDestination",
-		B_TRANSLATE("Log destination"), new BMessage(MSG_LOG_DESTINATION_CHANGED));
+		B_TRANSLATE("Log destination:"), new BMessage(MSG_LOG_DESTINATION_CHANGED));
 	fLogDestination->AddOptionAt("Stdout", Logger::LOGGER_DEST_STDOUT, 0);
 	fLogDestination->AddOptionAt("Stderr", Logger::LOGGER_DEST_STDERR, 1);
 	fLogDestination->AddOptionAt("Syslog", Logger::LOGGER_DEST_SYSLOG, 2);
 	fLogDestination->AddOptionAt("BeDC",   Logger::LOGGER_DEST_BEDC,   3);
 
 	fLogLevel = new BOptionPopUp("LogLevel",
-		B_TRANSLATE("Log level"), new BMessage(MSG_LOG_LEVEL_CHANGED));
+		B_TRANSLATE("Log level:"), new BMessage(MSG_LOG_LEVEL_CHANGED));
 	fLogLevel->AddOptionAt("Off", 1, 0);
 	fLogLevel->AddOptionAt("Error", 2, 1);
 	fLogLevel->AddOptionAt("Info", 3, 2);
@@ -1056,13 +1056,13 @@ SettingsWindow::_PageGeneralViewStartup()
 		B_TRANSLATE("Reload files"), new BMessage(MSG_REOPEN_FILES_TOGGLED));
 
 	fShowProjectsPanes = new BCheckBox("ShowProjectsPanes",
-		B_TRANSLATE("Show Projects panes"), new BMessage(MSG_SHOW_PROJECTS_PANES_TOGGLED));
+		B_TRANSLATE("Show projects panes"), new BMessage(MSG_SHOW_PROJECTS_PANES_TOGGLED));
 
 	fShowOutputPanes = new BCheckBox("ShowOutputPanes",
-		B_TRANSLATE("Show Output panes"), new BMessage(MSG_SHOW_OUTPUT_PANES_TOGGLED));
+		B_TRANSLATE("Show output panes"), new BMessage(MSG_SHOW_OUTPUT_PANES_TOGGLED));
 
 	fShowToolBar = new BCheckBox("ShowToolBar",
-		B_TRANSLATE("Show ToolBar"), new BMessage(MSG_SHOW_TOOLBAR_TOGGLED));
+		B_TRANSLATE("Show toolbar"), new BMessage(MSG_SHOW_TOOLBAR_TOGGLED));
 
 	BView* view = BGroupLayoutBuilder(B_VERTICAL, 0)
 		.Add(BLayoutBuilder::Grid<>(fGeneralStartupBox)


### PR DESCRIPTION
* Settings: To conform to the Haiku 'standard':
  - Rename button "Exit" -> "Cancel"
  - Rename button "Save" -> "OK"
  - "Projects directory" -> "Projects folder"

  - "Show full path in window title"
  - Sentence casing of Show x pane", same as in "Window" menu

* Edit menu:
  - "Switch to source/header" is more correct, I think

* App:
  - Improved alert text for missing/corrupt/old settings file. For button labels, it's best to repeat the action/verb of the instructive alert text ("Load" -> "Load defaults")
  - Make all of the about text translatable.

* General sentence casing, 'verbing' of menu items (e.g. "Zoom reset" -> "Reset zoom")