### PR TITLE
Improved translatability

### DIFF
--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,73 +1,71 @@
-1	English	application/x-vnd.Genio	1131137956
+1	English	application/x-vnd.Genio	1556747924
 Copy	GenioWindow		Copy
 Enable brace matching	SettingsWindow		Enable brace matching
-time	SettingsWindow		time
 Clear	ConsoleIOView		Clear
 Comment selected lines	GenioWindow		Comment selected lines
 Switch source/header	GenioWindow		Switch source/header
 Debug clean comand:	ProjectSettingsWindow		Debug clean comand:
+Make file read-only	GenioWindow		Make file read-only
 Show toolbar	GenioWindow		Show toolbar
 Debug build comand:	ProjectSettingsWindow		Debug build comand:
 Font:	SettingsWindow		Font:
 Build mode: Debug	GenioWindow		Build mode: Debug
-Delete lines	GenioWindow		Delete lines
+Show/Hide replace bar	GenioWindow		Show/Hide replace bar
 Replace selection	GenioWindow		Replace selection
-Set buffer read-only	GenioWindow		Set buffer read-only
-Select previous file	GenioWindow		Select previous file
 Problems	ProblemsPanel		Problems
 Open file	ProjectsFolderBrowser		Open file
 Edge column:	SettingsWindow		Edge column:
 Line endings	GenioWindow		Line endings
 Window	GenioWindow		Window
+Open files list	GenioWindow		Open files list
 Projects folder:	SettingsWindow		Projects folder:
+Set active	ProjectsFolderBrowser		Set active
 Genio is a fork of Ideam and available under the MIT license.	GenioApp		Genio is a fork of Ideam and available under the MIT license.
 Wrap	GenioWindow		Wrap
 Run in Terminal	ProjectSettingsWindow		Run in Terminal
 Save all	GenioWindow		Save all
 Go to line…	GenioWindow		Go to line…
+Log (oneline)	GenioWindow	The git command	Log (oneline)
 OK	GoToLineWindow		OK
-Pull (rebase)	GenioWindow		Pull (rebase)
 Select all	GenioWindow		Select all
 New folder	TemplateManager		New folder
-If kept and modified, save it or it will be lost	GenioWindow		If kept and modified, save it or it will be lost
-Startup	SettingsWindow		Startup
+Show/Hide find bar	GenioWindow		Show/Hide find bar
+Status	GenioWindow	The git command	Status
 Close file	GenioWindow		Close file
 Build log	GenioWindow		Build log
+Startup	SettingsWindow		Startup
 Find previous	GenioWindow		Find previous
+Show projects pane	SettingsWindow		Show projects pane
 Redo	GenioWindow		Redo
-Show output panes	GenioWindow		Show output panes
 Console I/O	GenioWindow		Console I/O
 Run	GenioWindow		Run
 Save current file	GenioWindow		Save current file
 Open Terminal	ProjectsFolderBrowser		Open Terminal
 Reload	GenioWindow		Reload
-Do you want to ignore, close or reload it?	GenioWindow		Do you want to ignore, close or reload it?
 Default	ProjectSettingsWindow		Default
 Project	GenioWindow		Project
 Replace	GenioWindow		Replace
 Load defaults	GenioApp		Load defaults
 Cancel	GenioWindow		Cancel
+Switch to previous file	GenioWindow		Switch to previous file
 Log level:	SettingsWindow		Log level:
 Release project target:	ProjectSettingsWindow		Release project target:
-Replace toggle (leaves Find bar open)	GenioWindow		Replace toggle (leaves Find bar open)
-Enable Notifications	SettingsWindow		Enable Notifications
-Build Commands	ProjectSettingsWindow		Build Commands
 Genio	System name		Genio
 OK	ProjectsFolderBrowser		OK
 Keep	GenioWindow		Keep
 Release	GenioWindow		Release
-Toggle	GenioWindow		Toggle
 Debug	GenioWindow		Debug
 Undo	GenioWindow		Undo
 Open recent…	GenioWindow		Open recent…
-Show config	GenioWindow		Show config
 Save	Editor		Save
 Autocomplete	GenioWindow		Autocomplete
+File \"%file%\" was apparently moved.\nDo you want to ignore, close or reload it?	GenioWindow		File \"%file%\" was apparently moved.\nDo you want to ignore, close or reload it?
 Convert to Mac	GenioWindow		Convert to Mac
-Deleting item:	GenioWindow		Deleting item:
 New file	GenioWindow		New file
-Read only	GenioWindow		Read only
 Project:	ProjectSettingsWindow		Project:
+Previous	GenioWindow	Bookmark menu	Previous
+Show output pane	GenioWindow		Show output pane
+Read-only	GenioWindow		Read-only
 Delete file	ProjectsFolderBrowser		Delete file
 Do you want to ignore, review or load defaults?	GenioApp		Do you want to ignore, review or load defaults?
 Find	GenioWindow		Find
@@ -76,45 +74,43 @@ Invalid project folder	GenioWindow		Invalid project folder
 Mark caret line	SettingsWindow		Mark caret line
 Build mode	GenioWindow		Build mode
 Wrap console	SettingsWindow		Wrap console
-Mark all	GenioWindow		Mark all
+Toggle	GenioWindow	Bookmark menu	Toggle
 Replace all	GenioWindow		Replace all
 Replace and find previous	GenioWindow		Replace and find previous
 Defaults loaded	SettingsWindow		Defaults loaded
 Debug project	GenioWindow		Debug project
 stderr	ConsoleIOView		stderr
 The settings file doesn't exist or is corrupted.	GenioApp		The settings file doesn't exist or is corrupted.
-File \"%file%\" was modified externally, reload it?	GenioWindow		File \"%file%\" was modified externally, reload it?
-File \"%file%\" was moved externally.	GenioWindow		File \"%file%\" was moved externally.
 Go to line:	GoToLineWindow		Go to line:
 Close project	GenioWindow		Close project
 Replace:	GenioWindow		Replace:
 Ignore	GenioWindow		Ignore
-Indexed file list	GenioWindow		Indexed file list
+Tag	GenioWindow	The git command	Tag
 Run console program	GenioWindow		Run console program
-Do you really want to delete it?	GenioWindow		Do you really want to delete it?
-Do you want to keep the file or discard it?	GenioWindow		Do you want to keep the file or discard it?
+Branch	GenioWindow	The git command	Branch
+Could not delete \"%name%\".\n\n	GenioWindow		Could not delete \"%name%\".\n\n
 New folder	GenioWindow		New folder
 Could not open template folder in Tracker	GenioWindow		Could not open template folder in Tracker
 Build	SettingsWindow		Build
+Another command is running.	ConsoleIOView		Another command is running.
 Duplicate current line	GenioWindow		Duplicate current line
 Clean project	GenioWindow		Clean project
 Release clean comand:	ProjectSettingsWindow		Release clean comand:
 Default	SettingsWindow		Default
-General	SettingsWindow		General
 Settings…	GenioWindow		Settings…
+General	SettingsWindow		General
 Release build comand:	ProjectSettingsWindow		Release build comand:
 Delete	GenioWindow		Delete
 Message	ProblemsPanel		Message
 Go to line	GoToLineWindow		Go to line
 Match case	GenioWindow		Match case
-File \"%file%\" was removed externally.	GenioWindow		File \"%file%\" was removed externally.
-Go to previous	GenioWindow		Go to previous
+Pull (rebase)	GenioWindow	The git command	Pull (rebase)
+Pull	GenioWindow	The git command	Pull
 Save	GenioWindow		Save
-applied	SettingsWindow		applied
-Find toggle (closes Replace bar if open)	GenioWindow		Find toggle (closes Replace bar if open)
 The project folder has been deleted or moved to another location and it will be closed and unloaded from the workspace.	ProjectsFolderBrowser		The project folder has been deleted or moved to another location and it will be closed and unloaded from the workspace.
-Quit	GenioWindow		Quit
 Go to declaration	GenioWindow		Go to declaration
+Quit	GenioWindow		Quit
+Switch to next file	GenioWindow		Switch to next file
 Show projects pane	GenioWindow		Show projects pane
 Log destination:	SettingsWindow		Log destination:
 Show edge line	SettingsWindow		Show edge line
@@ -127,13 +123,14 @@ stdout	ConsoleIOView		stdout
 Reload projects	SettingsWindow		Reload projects
 Console banner	SettingsWindow		Console banner
 Overwrite	GenioWindow		Overwrite
+Enable notifications	SettingsWindow		Enable notifications
 Edit user templates…	TemplatesMenu		Edit user templates…
 Go to definition	GenioWindow		Go to definition
 Save dialog	Editor		Save dialog
 Rename file	ProjectsFolderBrowser		Rename file
-Branch	GenioWindow		Branch
+Show output pane	SettingsWindow		Show output pane
+Status (short)	GenioWindow	The git command	Status (short)
 Don't save	GenioWindow		Don't save
-Show output panes	SettingsWindow		Show output panes
 Release execute arguments:	ProjectSettingsWindow		Release execute arguments:
 Search	GenioWindow		Search
 OK	ProjectSettingsWindow		OK
@@ -141,57 +138,49 @@ Save changes to file \"%file%\"	GenioWindow		Save changes to file \"%file%\"
 Exclude settings file from Git	ProjectSettingsWindow		Exclude settings file from Git
 Editor	SettingsWindow		Editor
 Banner	ConsoleIOView		Banner
-Log	GenioWindow		Log
 Error creating folder	GenioWindow		Error creating folder
-Save changes to file	Editor		Save changes to file
 Replace and find next	GenioWindow		Replace and find next
-Select next file	GenioWindow		Select next file
 Set to Mac	GenioWindow		Set to Mac
 Show/Hide projects pane	GenioWindow		Show/Hide projects pane
 Source	ProblemsPanel		Source
 Show full path in window title	SettingsWindow		Show full path in window title
-Show projects panes	SettingsWindow		Show projects panes
 See credits for a complete list.\n\n	GenioApp		See credits for a complete list.\n\n
 Build project	GenioWindow		Build project
 View	GenioWindow		View
 Don't save	Editor		Don't save
 Reset zoom	GenioWindow		Reset zoom
 Stop	ConsoleIOView		Stop
-tuned 	SettingsWindow		tuned 
 Signature help	GenioWindow		Signature help
 Tab width:  	SettingsWindow		Tab width:  
-Status	GenioWindow		Status
-After deletion the item will be lost.	GenioWindow		After deletion the item will be lost.
 Show toolbar	SettingsWindow		Show toolbar
 Revert	SettingsWindow		Revert
 Settings file for a previous version detected.	GenioApp		Settings file for a previous version detected.
-Log (oneline)	GenioWindow		Log (oneline)
 Whole word	GenioWindow		Whole word
 Made with love in Italy	GenioApp		Made with love in Italy
 Enable Git	ProjectSettingsWindow		Enable Git
 Default size	SettingsWindow		Default size
 Show comment margin	SettingsWindow		Show comment margin
+File \"%file%\" was apparently modified, reload it?	GenioWindow		File \"%file%\" was apparently modified, reload it?
 Cancel	GoToLineWindow		Cancel
+Bookmark all	GenioWindow		Bookmark all
 Appearance	GenioWindow		Appearance
 Cancel	Editor		Cancel
 File	GenioWindow		File
+Delete current line	GenioWindow		Delete current line
 Source control	ProjectSettingsWindow		Source control
 Reload files	SettingsWindow		Reload files
-Tag	GenioWindow		Tag
 The project folder has been renamed. It will be closed and reopened automatically.	ProjectsFolderBrowser		The project folder has been renamed. It will be closed and reopened automatically.
 Cut	GenioWindow		Cut
 Set for app ver: 	SettingsWindow		Set for app ver: 
 Font size:	SettingsWindow		Font size:
 Cancel	SettingsWindow		Cancel
 Zoom out	GenioWindow		Zoom out
-Pull	GenioWindow		Pull
-Another command is running..	ConsoleIOView		Another command is running..
 Save as…	GenioWindow		Save as…
 Set to Unix	GenioWindow		Set to Unix
-Clear all	GenioWindow		Clear all
+Log	GenioWindow	The git command	Log
+Show/Hide output pane	GenioWindow		Show/Hide output pane
+Show config	GenioWindow	The git command	Show config
 Projects	GenioWindow		Projects
-Set Active	ProjectsFolderBrowser		Set Active
-Show/Hide output panes	GenioWindow		Show/Hide output panes
 Go to implementation	GenioWindow		Go to implementation
 Run target	GenioWindow		Run target
 New	ProjectsFolderBrowser		New
@@ -205,45 +194,46 @@ Build mode: Release	GenioWindow		Build mode: Release
 Show in Tracker	ProjectsFolderBrowser		Show in Tracker
 Set to Dos	GenioWindow		Set to Dos
 Zoom in	GenioWindow		Zoom in
-Status (short)	GenioWindow		Status (short)
 Enable folding	SettingsWindow		Enable folding
 Apply	SettingsWindow		Apply
 Fold/Unfold all	GenioWindow		Fold/Unfold all
 Toggle white spaces	GenioWindow		Toggle white spaces
 New	GenioWindow		New
 Bookmark	GenioWindow		Bookmark
-Go to next	GenioWindow		Go to next
 Close all	GenioWindow		Close all
 You can't create a new folder here, please select a project or another folder	GenioWindow		You can't create a new folder here, please select a project or another folder
 Wrap	ConsoleIOView		Wrap
-Modifications	SettingsWindow		Modifications
-Find in files	GenioWindow		Find in files
+Next	GenioWindow	Bookmark menu	Next
+Clear all	GenioWindow	Bookmark menu	Clear all
+File \"%file%\" was apparently removed.\nDo you want to keep the file or discard it?\nIf kept and modified, save it or it will be lost.	GenioWindow		File \"%file%\" was apparently removed.\nDo you want to keep the file or discard it?\nIf kept and modified, save it or it will be lost.
 Review	GenioApp		Review
 Cancel	ProjectSettingsWindow		Cancel
 An error occurred attempting to rename file 	ProjectsFolderBrowser		An error occurred attempting to rename file 
-Controls loaded.	SettingsWindow		Controls loaded.
 Delete dialog	GenioWindow		Delete dialog
 Show line number	SettingsWindow		Show line number
 Target	ProjectSettingsWindow		Target
+Find in project	GenioWindow		Find in project
 About…	GenioWindow		About…
 Debug execute arguments:	ProjectSettingsWindow		Debug execute arguments:
 Category	ProblemsPanel		Category
 Debug project target:	ProjectSettingsWindow		Debug project target:
 Close	GenioWindow		Close
+Save changes to file \"%filename%\"?	Editor		Save changes to file \"%filename%\"?
 Genio uses:\nScintilla lib\nCopyright 1998-2003 by Neil Hodgson <neilh@scintilla.org>\n\nScintilla for Haiku\nCopyright 2011 by Andrea Anzani <andrea.anzani@gmail.com>\nCopyright 2014-2015 by Kacper Kasper <kacperkasper@gmail.com>\n\n	GenioApp		Genio uses:\nScintilla lib\nCopyright 1998-2003 by Neil Hodgson <neilh@scintilla.org>\n\nScintilla for Haiku\nCopyright 2011 by Andrea Anzani <andrea.anzani@gmail.com>\nCopyright 2014-2015 by Kacper Kasper <kacperkasper@gmail.com>\n\n
 Open project	GenioWindow		Open project
 Ignore	GenioApp		Ignore
 Edit	GenioWindow		Edit
 There are modified files, do you want to save changes before quitting?	GenioWindow		There are modified files, do you want to save changes before quitting?
+Deleting item: \"%name%\".\n\nAfter deletion, the item will be lost.\nDo you really want to delete it?	GenioWindow		Deleting item: \"%name%\".\n\nAfter deletion, the item will be lost.\nDo you really want to delete it?
 Find next	GenioWindow		Find next
 Notifications	SettingsWindow		Notifications
 Find:	GenioWindow		Find:
 This is the font size preview	SettingsWindow		This is the font size preview
 Git	GenioWindow		Git
-times	SettingsWindow		times
 OK	Utilities		OK
 Project settings…	GenioWindow		Project settings…
 Paste	GenioWindow		Paste
 Visual	SettingsWindow		Visual
 Convert to Unix	GenioWindow		Convert to Unix
+Build commands	ProjectSettingsWindow		Build commands
 Save caret position	SettingsWindow		Save caret position

--- a/locales/it.catkeys
+++ b/locales/it.catkeys
@@ -1,332 +1,239 @@
-1	English	application/x-vnd.Genio-Genio	2426676650
-tuned 	SettingsWindow		settato
-bytes	GenioWindow		bytes
-C source file	AddToProjectWindow		C source file
-A C command line \"Hello World!\" application	NewProject Window		Applicazione C \"Hello World!\" da linea di comando
-Find	GenioWindow		Trova
-time	SettingsWindow		time
-Load	GenioApp		Carica
-File save:	GenioWindow		File save:
-ERROR: Settings directory not found	GenioWindow		ERRORE: Settings directory not found
-Replace toggle (leaves Find bar open)	GenioWindow		Sostituisci (non chiude barra Trova)
-Delete project	GenioWindow		Elimina progetto
-Existing project with Makefile.	NewProject Window		Existing project with Makefile.
-Search	GenioWindow		Cerca
-File \"%file%\" was removed externally,	GenioWindow		File \"%file%\" was removed externally,
-Run console program	GenioWindow		Run console program
-written	GenioWindow		written
-Toggle Projects panes	GenioWindow		On/Off pannelli dei Progetti
-Console banner	SettingsWindow		Console banner
-NOTE: Extensions automatically added	AddToProjectWindow		NOTE: Extensions automatically added
-Removing stale dir:	NewProject Window		Removing stale dir:
-Stop	ConsoleIOView		Stop
-Local app dir:	NewProject Window		Directory locale:
-Project target:	NewProject Window		Target del progetto:
-Project [host architecture: 	NewProject Window		Project [host architecture: 
-Import	NewProject Window		Importa
-Console I/O	GenioWindow		Console I/O
-Startup	SettingsWindow		Avvio
-Enable Git	NewProject Window		Enable Git
-Please fill \"Local app dir\" field	NewProject Window		Riempire campo \"Dir. locale\"
-uses:	GenioApp		uses:
-Parseless files	ProjectSettingsWindow		Parseless files
-You should make sure that the rust package (read cargo binary) is installed and working!	NewProject Window		You should make sure that the rust package (read cargo binary) is installed and working!
-Find Next	GenioWindow		Trova successivo
-removed	GenioWindow		removed
-Help	GenioWindow		Aiuto
-Programming: Principles and Practice using C++ (2nd edition)	NewProject Window		Programming: Principles and Practice using C++ (2nd edition)
-About…	GenioWindow		About…
-Reload projects	SettingsWindow		Reload projects
-* Clone Haiku repo and configure it.	NewProject Window		* Clone Haiku repo and configure it.
-C Hello World!	NewProject Window		C Hello World!
-Cargo project	NewProject Window		Cargo project
-Show/Hide Output split	GenioWindow		Mostra/Nascondi split di Output
-Empty Project	NewProject Window		Progetto vuoto
-Run target	GenioWindow		Run target
-Please fill \"Haiku app dir\" field	NewProject Window		Please fill \"Haiku app dir\" field
-A project file with an empty project directory.	NewProject Window		A project file with an empty project directory.
-Browse…	NewProject Window		Browse…
-Build mode: Release	GenioWindow		Build mode: Release
-Delete file dialog	GenioWindow		Delete file dialog
-A C++ command line \"Hello World!\" application	NewProject Window		A C++ command line \"Hello World!\" application
-Please fill \"Project name\" field	NewProject Window		Please fill \"Project name\" field
-contained in Bjarne Stroustrup' s book:	NewProject Window		contained in Bjarne Stroustrup' s book:
-Show ToolBar	SettingsWindow		Mostra ToolBar
-Replace	GenioWindow		Sostituisci
-occurrences found:	GenioWindow		occurrences found:
+1	English	application/x-vnd.Genio	1556747924
+Copy	GenioWindow		Copia
+Enable brace matching	SettingsWindow		Enable brace matching
+Clear	ConsoleIOView		Clear
+Comment selected lines	GenioWindow		Comment selected lines
+Switch source/header	GenioWindow		Switch source/header
+Debug clean comand:	ProjectSettingsWindow		Debug clean comand:
+Make file read-only	GenioWindow		Make file read-only
+Show toolbar	GenioWindow		Show toolbar
+Debug build comand:	ProjectSettingsWindow		Debug build comand:
+Font:	SettingsWindow		Font:
+Build mode: Debug	GenioWindow		Build mode: Debug
+Show/Hide replace bar	GenioWindow		Show/Hide replace bar
+Replace selection	GenioWindow		Sostituisci selezione
+Problems	ProblemsPanel		Problems
+Open file	ProjectsFolderBrowser		Open file
+Edge column:	SettingsWindow		Colonna di margine a:
+Line endings	GenioWindow		Line endings
+Window	GenioWindow		Finestra
+Open files list	GenioWindow		Open files list
+Projects folder:	SettingsWindow		Projects folder:
+Set active	ProjectsFolderBrowser		Set active
+Genio is a fork of Ideam and available under the MIT license.	GenioApp		Genio is a fork of Ideam and available under the MIT license.
+Wrap	GenioWindow		Wrap
+Run in Terminal	ProjectSettingsWindow		Run in Terminal
+Save all	GenioWindow		Salva tutti
 Go to line…	GenioWindow		Vai alla riga…
-Set to Unix	GenioWindow		Set to Unix
-Save current File	GenioWindow		Salva il File corrente
-e.g. /boot/home/repodir/haiku/src/apps/clock	NewProject Window		e.g. /boot/home/repodir/haiku/src/apps/clock
-Project open:	GenioWindow		Project open:
-Sources too	GenioWindow		Sources too
-Project scan	ProjectParser		Project scan
-Pull	GenioWindow		Pull
-Add header	NewProject Window		Add header
-applied	SettingsWindow		applied
-Pull (Rebase)	GenioWindow		Pull (Rebase)
-stderr	ConsoleIOView		stderr
-do You want to ignore, close or reload it?	GenioWindow		do You want to ignore, close or reload it?
+Log (oneline)	GenioWindow	The git command	Log (oneline)
+OK	GoToLineWindow		OK
+Select all	GenioWindow		Seleziona tutto
+New folder	TemplateManager		New folder
+Show/Hide find bar	GenioWindow		Show/Hide find bar
+Status	GenioWindow	The git command	Status
+Close file	GenioWindow		Close file
+Build log	GenioWindow		Build log
+Startup	SettingsWindow		Avvio
+Find previous	GenioWindow		Trova precedente
+Show projects pane	SettingsWindow		Show projects pane
+Redo	GenioWindow		Ripeti
+Console I/O	GenioWindow		Console I/O
+Run	GenioWindow		Run
+Save current file	GenioWindow		Save current file
+Open Terminal	ProjectsFolderBrowser		Open Terminal
+Reload	GenioWindow		Ricarica
+Default	ProjectSettingsWindow		Default
 Project	GenioWindow		Progetto
-ERROR: empty \"TARGET\" in Makefile	NewProject Window		ERROR: empty \"TARGET\" in Makefile
-File \"%file%\" was moved externally,	GenioWindow		File \"%file%\" was moved externally,
-Project delete:	GenioWindow		Project delete:
-Match case	GenioWindow		Match case
-Replace and find next	GenioWindow		Sostituisci e trova il prossimo
+Replace	GenioWindow		Sostituisci
+Load defaults	GenioApp		Load defaults
+Cancel	GenioWindow		Cancella
+Switch to previous file	GenioWindow		Switch to previous file
+Log level:	SettingsWindow		Log level:
+Release project target:	ProjectSettingsWindow		Release project target:
+Genio	System name		Genio
+OK	ProjectsFolderBrowser		OK
+Keep	GenioWindow		Mantieni
+Release	GenioWindow		Release
+Debug	GenioWindow		Debug
+Undo	GenioWindow		Annulla
+Open recent…	GenioWindow		File recenti…
+Save	Editor		Salva
+Autocomplete	GenioWindow		Autocomplete
+File \"%file%\" was apparently moved.\nDo you want to ignore, close or reload it?	GenioWindow		File \"%file%\" was apparently moved.\nDo you want to ignore, close or reload it?
+Convert to Mac	GenioWindow		Converti a Mac
+New file	GenioWindow		New file
+Project:	ProjectSettingsWindow		Project:
+Previous	GenioWindow	Bookmark menu	Previous
+Show output pane	GenioWindow		Show output pane
+Read-only	GenioWindow		Read-only
+Delete file	ProjectsFolderBrowser		Delete file
+Do you want to ignore, review or load defaults?	GenioApp		Do you want to ignore, review or load defaults?
+Find	GenioWindow		Trova
+Discard	GenioWindow		Elimina
+Invalid project folder	GenioWindow		Invalid project folder
+Mark caret line	SettingsWindow		Evidenzia linea del cursore
 Build mode	GenioWindow		Build mode
 Wrap console	SettingsWindow		Wrap console
-Reload files	SettingsWindow		Ricarica i file
-Save changes to file \"%file%\"	GenioWindow		Salva cambiamenti al file \"%file%\"
-Cut	GenioWindow		Taglia
-Replace:	GenioWindow		Sostituisci:
-Library target when unchecked	NewProject Window		Library target when unchecked
-Please choose a project first	NewProject Window		Please choose a project first
-Log (Oneline)	GenioWindow		Log (Oneline)
-Run	GenioWindow		Run
-Application with menu	NewProject Window		Application with menu
-removed externally	GenioWindow		removed externally
-Project Sources	GenioWindow		Project Sources
-Editor	SettingsWindow		Editor
-Select all	GenioWindow		Seleziona tutto
-Delete	GenioWindow		Elimina
-do You want to ignore, review or load to defaults?	GenioApp		do You want to ignore, review or load to defaults?
-Close project	GenioWindow		Chiudi progetto
-Undo	GenioWindow		Annulla
-Type	GenioWindow		Tipo
-Go to next	GenioWindow		Vai al prossimo
-Defaults loaded	SettingsWindow		Predefiniti caricati
-Show Projects panes	SettingsWindow		Mostra pannelli dei Progetti
-Notifications	GenioWindow		Notifiche
-Don't save	Editor		Non salvare
-Default	SettingsWindow		Default
-Ignore	GenioApp		Ignora
-Build Project	GenioWindow		Build Project
-Clean started:	GenioWindow		Clean started:
-Generic	AddToProjectWindow		Generic
-Time	GenioWindow		Data
-Choose Project:	ProjectSettingsWindow		Choose Project:
-Toggle ToolBar	GenioWindow		On/Off barra Strumenti
-Deleting project:	GenioWindow		Deleting project:
-Font size:	SettingsWindow		Dimensione Font:
-update	GenioWindow		update
-Set to Mac	GenioWindow		Set to Mac
-Select previous File	GenioWindow		Seleziona il File precedente
-Runtime	ProjectSettingsWindow		Runtime
-Save caret position	SettingsWindow		Salva posizione cursore
-New	GenioWindow		Nuovo
-There are modified files, do you want to save changes before quitting?	GenioWindow		Ci sono file modificati, vuoi salvare le modifiche prima di uscire?
-Convert to Dos	GenioWindow		Converti a Dos
-Build	GenioWindow		Build
-Redo	GenioWindow		Ripeti
-NOTE: first compilation may take a long time to complete	NewProject Window		NOTE: first compilation may take a long time to complete
-Convert to Mac	GenioWindow		Converti a Mac
-Find:	GenioWindow		Trova:
-Build Log	GenioWindow		Build Log
-Build	SettingsWindow		Build
-Interface	GenioWindow		Interfaccia
-Project Files	GenioWindow		Project Files
-Toggle Output panes	GenioWindow		On/Off pannelli di Output
-Project close:	GenioWindow		Project close:
-Find toggle (closes Replace bar if open)	GenioWindow		Trova (chiude barra Sost. se aperta)
-Paste	GenioWindow		Incolla
-C/C++ Project with Makefile	NewProject Window		C/C++ Project with Makefile
-Disables vcs management when checked	NewProject Window		Disables vcs management when checked
-Find previous not found	GenioWindow		Find previous not found
-Discard	GenioWindow		Elimina
-ERROR: Project directory exists!	NewProject Window		ERROR: Project directory exists!
-Window	GenioWindow		Finestra
-Generic file	AddToProjectWindow		Generic file
-Set Active	GenioWindow		Set Active
-Edge column:	SettingsWindow		Colonna di margine a:
-Log	GenioWindow		Log
-Cargo	AddToProjectWindow		Cargo
-Debug	GenioWindow		Debug
-C++ source file	AddToProjectWindow		C++ source file
-Wrap	GenioWindow		Wrap
-Directory:	AddToProjectWindow		Directory:
-Debug Project	GenioWindow		Debug Project
-Set to Dos	GenioWindow		Set to Dos
-Banner	ConsoleIOView		Banner
-do You want to keep the file or discard it?	GenioWindow		do You want to keep the file or discard it?
-Source control:	ProjectSettingsWindow		Source control:
-cargo binary not found!	NewProject Window		cargo binary not found!
-Find next not found	GenioWindow		Find next not found
-Revert	SettingsWindow		Ripristina
-ERROR: empty \"NAME\" in Makefile	NewProject Window		ERROR: empty \"NAME\" in Makefile
-Branch	GenioWindow		Branch
-Save position	SettingsWindow		Salva posizione
-Set buffer read-only	GenioWindow		Imposta il buffer a sola lettura
-Open file	GenioWindow		Open file
-Steps (read Haiku guides if unsure):	NewProject Window		Steps (read Haiku guides if unsure):
-modified externally	GenioWindow		modified externally
-Show Output panes	SettingsWindow		Mostra pannelli di Output
-File open:	GenioWindow		File open:
-Principles and Practice (2nd)	NewProject Window		Principles and Practice (2nd)
-Select next File	GenioWindow		Seleziona il File seguente
-Do you want to delete project sources too?	GenioWindow		Do you want to delete project sources too?
-Review	GenioApp		Revisiona
-Message	GenioWindow		Messaggio
-Enable Notifications	SettingsWindow		Abilita Notifiche
-Next Bookmark not found	GenioWindow		Segnalibro successivo non trovato
-Active project open:	GenioWindow		Active project open:
-File full path in window title	SettingsWindow		Percorso del File nel titolo
-Wrap	ConsoleIOView		Wrap
-File \"%file%\" was modified externally, reload it?	GenioWindow		Il File \"%file%\" è stato modificato da un altra applicazione, lo ricarico?
-Project target:	ProjectSettingsWindow		Project target:
-C/C++ Makefile	AddToProjectWindow		C/C++ Makefile
-A rust cargo project.	NewProject Window		A rust cargo project.
-Clear	ConsoleIOView		Clear
-A GUI application with menu bar and localization	NewProject Window		A GUI application with menu bar and localization
-Editables	ProjectSettingsWindow		Editables
-stdout	ConsoleIOView		stdout
-Show comment margin	SettingsWindow		Show comment margin
-A simple GUI \"Hello World!\" application	NewProject Window		A simple GUI \"Hello World!\" application
-Delete file	GenioWindow		Delete file
-Bookmark	GenioWindow		Segnalibro
-NOTE: sources not copied or moved	NewProject Window		NOTE: sources not copied or moved
-Save	GenioWindow		Salva
-Quit	GenioWindow		Esci
-exists!	NewProject Window		exists!
-File is Read-only	GenioWindow		File di sola lettura
-Save	Editor		Salva
-C++ Hello World!	NewProject Window		C++ Hello World!
-Clear all	GenioWindow		Pulisci tutti
-Exclude file	GenioWindow		Exclude file
-Show/Hide Projects split	GenioWindow		Mostra/Nascondi split dei Progetti
-Toggle line endings	GenioWindow		Mostra i fine riga
-Open	GenioWindow		Apri
-Run Project	GenioWindow		Run Project
-Exit	ProjectSettingsWindow		Exit
-Index	GenioWindow		Index
-File	GenioWindow		File
-Show line number	SettingsWindow		Mostra numeri di linea
-C/C++ header file	AddToProjectWindow		C/C++ header file
-Font:	SettingsWindow		Font:
-Git	GenioWindow		Git
-C/C++	AddToProjectWindow		C/C++
-* Click \"Create\" button	NewProject Window		* Click \"Create\" button
-No file selected	GenioWindow		Nessun file selezionato
-Previous Bookmark not found	GenioWindow		Segnalibro precedente non trovato
-Apply	SettingsWindow		Applica
-repodir>  git clone https://git.haiku-os.org/haiku	NewProject Window		repodir>  git clone https://git.haiku-os.org/haiku
-ERROR: Project 	NewProject Window		ERROR: Project
-Do you really want to delete it?	GenioWindow		Do you really want to delete it?
-Open recent…	GenioWindow		File recenti…
-Genio	System name		Genio
-available under the MIT license.	GenioApp		available under the MIT license.
-Clean comand:	ProjectSettingsWindow		Clean comand:
-It may be filled in Project->Settings menu	NewProject Window		It may be filled in Project->Settings menu
-Ignore	GenioWindow		Ignora
-Cargo	GenioWindow		Cargo
-Indexed File list	GenioWindow		Lista dei File indicizzata
-Copy	GenioWindow		Copia
-Overwrite	GenioWindow		Sovrascrivi
-Exit	AddToProjectWindow		Exit
-This is the font size preview	SettingsWindow		This is the font size preview
-Project name:	NewProject Window		Nome del Progetto:
-Rescan	GenioWindow		Rescan
-Project only	GenioWindow		Project only
-* Select your Haiku app dir (from src/apps) or write full path in text control	NewProject Window		* Select your Haiku app dir (from src/apps) or write full path in text control
-Modifications	SettingsWindow		Modifications
-Replacements done:	GenioWindow		Replacements done:
-Save all	GenioWindow		Salva tutti
-After deletion file will be lost.	GenioWindow		After deletion file will be lost.
-Cancel	Editor		Cancella
-File close:	GenioWindow		File close:
-Don't save	GenioWindow		Non salvare
-Save dialog	Editor		Salva dialog
-Once done get back here and:	NewProject Window		Once done get back here and:
-Project type:	ProjectSettingsWindow		Project type:
-Browse…	SettingsWindow		Browse…
-Status (Short)	GenioWindow		Status (Short)
-Name:	AddToProjectWindow		Name:
-App from Haiku sources	NewProject Window		App from Haiku sources
-Show edge line	SettingsWindow		Mostra margine
-Save all Files	GenioWindow		Salva tutti i File
-Notifications	SettingsWindow		Notifiche
-Status	GenioWindow		Status
-Exit	SettingsWindow		Esci
-Makefile	AddToProjectWindow		Makefile
-Reload	GenioWindow		Ricarica
-Projects dir:	NewProject Window		Projects dir:
-Add Item	AddToProjectWindow		Add Item
-Clean Project	GenioWindow		Clean Project
-Please fill \"Add file\" field	NewProject Window		Please fill \"Add file\" field
-Mark all	GenioWindow		Segna tutti
-Build mode: Debug	GenioWindow		Build mode: Debug
-Find in files	GenioWindow		Trova nei file
-Release	GenioWindow		Release
-Line endings	GenioWindow		Line endings
-Settings	GenioWindow		Impostazioni
-Enable Brace matching	SettingsWindow		Abilita corrispondenza parentesi
-An application template for programs	NewProject Window		An application template for programs
-Whole word	GenioWindow		Parola intera
-Close all	GenioWindow		Chiudi tutti
-Replace selection	GenioWindow		Sostituisci selezione
-Run in Terminal	NewProject Window		Run in Terminal
-Active project close:	GenioWindow		Active project close:
-Show Config	GenioWindow		Show Config
-Set for app ver: 	SettingsWindow		Per la versione: 
-Close	GenioWindow		Chiudi
-Build comand:	ProjectSettingsWindow		Build comand:
-Enable Syntax highlighting	SettingsWindow		Abilita colorazione sintassi
-Visual	SettingsWindow		Visuale
-Haiku Makefile	AddToProjectWindow		Haiku Makefile
-Delete project dialog	GenioWindow		Delete project dialog
-times	SettingsWindow		times
-Save as…	GenioWindow		Salva con nome…
-Replace and find previous	GenioWindow		Sostituisci e trova precedente
-Go to previous	GenioWindow		Vai al precedente
-Settings file is corrupted or deleted,	GenioApp		Settings file is corrupted or deleted,
-Find previous	GenioWindow		Trova precedente
-Please fill \"Project target\" field	NewProject Window		Please fill \"Project target\" field
-Deleting file:	GenioWindow		Deleting file:
-or edit Makefile variable (SYSTEM_INCLUDE_PATHS) accordingly	NewProject Window		or edit Makefile variable (SYSTEM_INCLUDE_PATHS) accordingly
-Edit	GenioWindow		Modifica
-C++ class	AddToProjectWindow		C++ class
-Add to Project	GenioWindow		Add to Project
-Create	NewProject Window		Create
-cargo path:	NewProject Window		cargo path:
-NULL editor pointer	GenioWindow		puntatore dell' editor NULL
-Runtime args:	ProjectSettingsWindow		Runtime args:
-Add	AddToProjectWindow		Add
-repodir/haiku> ./configure --use-gcc-pipe	NewProject Window		repodir/haiku> ./configure --use-gcc-pipe
-Fold	GenioWindow		Fold
-Application	NewProject Window		Application
-Removing stale file:	NewProject Window		Removing stale file:
-Project open fail:	GenioWindow		Project open fail:
-Rust	NewProject Window		Rust
-Toggle	GenioWindow		Toggle
-Mark caret line	SettingsWindow		Evidenzia linea del cursore
-Save changes to file	Editor		Salva i cambiamenti su file
-Settings file for a previous version detected,	GenioApp		Settings file for a previous version detected,
+Toggle	GenioWindow	Bookmark menu	Toggle
 Replace all	GenioWindow		Sostituisci tutti
-Invalid selection	NewProject Window		Invalid selection
-ERROR: Project creation failed	NewProject Window		ERROR: Project creation failed
-Controls loaded.	SettingsWindow		Controls loaded.
-* Accord \"generated\" target dir (in \"Project target:\") if needed	NewProject Window		* Accord \"generated\" target dir (in \"Project target:\") if needed
-Cancel	GenioWindow		Cancella
-Enable folding	SettingsWindow		Abilita folding
-Fold toggle	GenioWindow		Fold toggle
-Tab width:  	SettingsWindow		Tabulazioni: 
-Project:	ProjectSettingsWindow		Project:
-File info:	GenioWindow		File info:
-Removing stale empty dir:	NewProject Window		Removing stale empty dir:
-See Credits for a complete list.	GenioApp		Vedi Credits per una lista completa.
-Projects	GenioWindow		Progetti
-Projects directory:	SettingsWindow		Directory dei Progetti:
-An application from Haiku sources repo.	NewProject Window		An application from Haiku sources repo.
-moved externally to	GenioWindow		moved externally to
-Removing stale project file:	NewProject Window		Removing stale project file:
+Replace and find previous	GenioWindow		Sostituisci e trova precedente
+Defaults loaded	SettingsWindow		Predefiniti caricati
+Debug project	GenioWindow		Debug project
+stderr	ConsoleIOView		stderr
+The settings file doesn't exist or is corrupted.	GenioApp		The settings file doesn't exist or is corrupted.
+Go to line:	GoToLineWindow		Go to line:
+Close project	GenioWindow		Chiudi progetto
+Replace:	GenioWindow		Sostituisci:
+Ignore	GenioWindow		Ignora
+Tag	GenioWindow	The git command	Tag
+Run console program	GenioWindow		Run console program
+Branch	GenioWindow	The git command	Branch
+Could not delete \"%name%\".\n\n	GenioWindow		Could not delete \"%name%\".\n\n
+New folder	GenioWindow		New folder
+Could not open template folder in Tracker	GenioWindow		Could not open template folder in Tracker
+Build	SettingsWindow		Build
+Another command is running.	ConsoleIOView		Another command is running.
+Duplicate current line	GenioWindow		Duplicate current line
+Clean project	GenioWindow		Clean project
+Release clean comand:	ProjectSettingsWindow		Release clean comand:
+Default	SettingsWindow		Default
+Settings…	GenioWindow		Settings…
 General	SettingsWindow		Generale
-Select project directory and accord \"Project target:\" if needed	NewProject Window		Select project directory and accord \"Project target:\" if needed
-Tag	GenioWindow		Tag
-If kept and modified save it or it will be lost	GenioWindow		If kept and modified save it or it will be lost
-Put \"std_lib_facilities.h\" in:	NewProject Window		Put \"std_lib_facilities.h\" in:
+Release build comand:	ProjectSettingsWindow		Release build comand:
+Delete	GenioWindow		Elimina
+Message	ProblemsPanel		Message
+Go to line	GoToLineWindow		Go to line
+Match case	GenioWindow		Match case
+Pull (rebase)	GenioWindow	The git command	Pull (rebase)
+Pull	GenioWindow	The git command	Pull
+Save	GenioWindow		Salva
+The project folder has been deleted or moved to another location and it will be closed and unloaded from the workspace.	ProjectsFolderBrowser		The project folder has been deleted or moved to another location and it will be closed and unloaded from the workspace.
+Go to declaration	GenioWindow		Go to declaration
+Quit	GenioWindow		Esci
+Switch to next file	GenioWindow		Switch to next file
+Show projects pane	GenioWindow		Show projects pane
+Log destination:	SettingsWindow		Log destination:
+Show edge line	SettingsWindow		Mostra margine
+Help	GenioWindow		Aiuto
+Open	GenioWindow		Apri
+Toggle line endings	GenioWindow		Mostra i fine riga
+Convert to Dos	GenioWindow		Converti a Dos
+Save all files	GenioWindow		Save all files
+stdout	ConsoleIOView		stdout
+Reload projects	SettingsWindow		Reload projects
+Console banner	SettingsWindow		Console banner
+Overwrite	GenioWindow		Sovrascrivi
+Enable notifications	SettingsWindow		Enable notifications
+Edit user templates…	TemplatesMenu		Edit user templates…
+Go to definition	GenioWindow		Go to definition
+Save dialog	Editor		Salva dialog
+Rename file	ProjectsFolderBrowser		Rename file
+Show output pane	SettingsWindow		Show output pane
+Status (short)	GenioWindow	The git command	Status (short)
+Don't save	GenioWindow		Non salvare
+Release execute arguments:	ProjectSettingsWindow		Release execute arguments:
+Search	GenioWindow		Cerca
+OK	ProjectSettingsWindow		OK
+Save changes to file \"%file%\"	GenioWindow		Salva cambiamenti al file \"%file%\"
+Exclude settings file from Git	ProjectSettingsWindow		Exclude settings file from Git
+Editor	SettingsWindow		Editor
+Banner	ConsoleIOView		Banner
+Error creating folder	GenioWindow		Error creating folder
+Replace and find next	GenioWindow		Sostituisci e trova il prossimo
+Set to Mac	GenioWindow		Set to Mac
+Show/Hide projects pane	GenioWindow		Show/Hide projects pane
+Source	ProblemsPanel		Source
+Show full path in window title	SettingsWindow		Show full path in window title
+See credits for a complete list.\n\n	GenioApp		See credits for a complete list.\n\n
+Build project	GenioWindow		Build project
+View	GenioWindow		View
+Don't save	Editor		Non salvare
+Reset zoom	GenioWindow		Reset zoom
+Stop	ConsoleIOView		Stop
+Signature help	GenioWindow		Signature help
+Tab width:  	SettingsWindow		Tabulazioni: 
+Show toolbar	SettingsWindow		Show toolbar
+Revert	SettingsWindow		Ripristina
+Settings file for a previous version detected.	GenioApp		Settings file for a previous version detected.
+Whole word	GenioWindow		Parola intera
+Made with love in Italy	GenioApp		Made with love in Italy
+Enable Git	ProjectSettingsWindow		Enable Git
+Default size	SettingsWindow		Default size
+Show comment margin	SettingsWindow		Show comment margin
+File \"%file%\" was apparently modified, reload it?	GenioWindow		File \"%file%\" was apparently modified, reload it?
+Cancel	GoToLineWindow		Cancel
+Bookmark all	GenioWindow		Bookmark all
+Appearance	GenioWindow		Appearance
+Cancel	Editor		Cancella
+File	GenioWindow		File
+Delete current line	GenioWindow		Delete current line
+Source control	ProjectSettingsWindow		Source control
+Reload files	SettingsWindow		Ricarica i file
+The project folder has been renamed. It will be closed and reopened automatically.	ProjectsFolderBrowser		The project folder has been renamed. It will be closed and reopened automatically.
+Cut	GenioWindow		Taglia
+Set for app ver: 	SettingsWindow		Per la versione: 
+Font size:	SettingsWindow		Dimensione Font:
+Cancel	SettingsWindow		Cancel
+Zoom out	GenioWindow		Zoom out
+Save as…	GenioWindow		Salva con nome…
+Set to Unix	GenioWindow		Set to Unix
+Log	GenioWindow	The git command	Log
+Show/Hide output pane	GenioWindow		Show/Hide output pane
+Show config	GenioWindow	The git command	Show config
+Projects	GenioWindow		Progetti
+Go to implementation	GenioWindow		Go to implementation
+Run target	GenioWindow		Run target
+New	ProjectsFolderBrowser		New
+Could not create a new file	GenioWindow		Could not create a new file
+Browse…	SettingsWindow		Browse…
+Close project	ProjectsFolderBrowser		Close project
+Save position	SettingsWindow		Salva posizione
+Format	GenioWindow		Format
+Enable syntax highlighting	SettingsWindow		Enable syntax highlighting
+Build mode: Release	GenioWindow		Build mode: Release
+Show in Tracker	ProjectsFolderBrowser		Show in Tracker
+Set to Dos	GenioWindow		Set to Dos
+Zoom in	GenioWindow		Zoom in
+Enable folding	SettingsWindow		Abilita folding
+Apply	SettingsWindow		Applica
+Fold/Unfold all	GenioWindow		Fold/Unfold all
 Toggle white spaces	GenioWindow		Mostra gli spazi bianchi
-Exit	NewProject Window		Exit
+New	GenioWindow		Nuovo
+Bookmark	GenioWindow		Segnalibro
+Close all	GenioWindow		Chiudi tutti
+You can't create a new folder here, please select a project or another folder	GenioWindow		You can't create a new folder here, please select a project or another folder
+Wrap	ConsoleIOView		Wrap
+Next	GenioWindow	Bookmark menu	Next
+Clear all	GenioWindow	Bookmark menu	Pulisci tutti
+File \"%file%\" was apparently removed.\nDo you want to keep the file or discard it?\nIf kept and modified, save it or it will be lost.	GenioWindow		File \"%file%\" was apparently removed.\nDo you want to keep the file or discard it?\nIf kept and modified, save it or it will be lost.
+Review	GenioApp		Revisiona
+Cancel	ProjectSettingsWindow		Cancel
+An error occurred attempting to rename file 	ProjectsFolderBrowser		An error occurred attempting to rename file 
+Delete dialog	GenioWindow		Delete dialog
+Show line number	SettingsWindow		Mostra numeri di linea
+Target	ProjectSettingsWindow		Target
+Find in project	GenioWindow		Find in project
+About…	GenioWindow		About…
+Debug execute arguments:	ProjectSettingsWindow		Debug execute arguments:
+Category	ProblemsPanel		Category
+Debug project target:	ProjectSettingsWindow		Debug project target:
+Close	GenioWindow		Chiudi
+Save changes to file \"%filename%\"?	Editor		Save changes to file \"%filename%\"?
+Genio uses:\nScintilla lib\nCopyright 1998-2003 by Neil Hodgson <neilh@scintilla.org>\n\nScintilla for Haiku\nCopyright 2011 by Andrea Anzani <andrea.anzani@gmail.com>\nCopyright 2014-2015 by Kacper Kasper <kacperkasper@gmail.com>\n\n	GenioApp		Genio uses:\nScintilla lib\nCopyright 1998-2003 by Neil Hodgson <neilh@scintilla.org>\n\nScintilla for Haiku\nCopyright 2011 by Andrea Anzani <andrea.anzani@gmail.com>\nCopyright 2014-2015 by Kacper Kasper <kacperkasper@gmail.com>\n\n
+Open project	GenioWindow		Open project
+Ignore	GenioApp		Ignora
+Edit	GenioWindow		Modifica
+There are modified files, do you want to save changes before quitting?	GenioWindow		Ci sono file modificati, vuoi salvare le modifiche prima di uscire?
+Deleting item: \"%name%\".\n\nAfter deletion, the item will be lost.\nDo you really want to delete it?	GenioWindow		Deleting item: \"%name%\".\n\nAfter deletion, the item will be lost.\nDo you really want to delete it?
+Find next	GenioWindow		Find next
+Notifications	SettingsWindow		Notifiche
+Find:	GenioWindow		Trova:
+This is the font size preview	SettingsWindow		This is the font size preview
+Git	GenioWindow		Git
+OK	Utilities		OK
+Project settings…	GenioWindow		Project settings…
+Paste	GenioWindow		Incolla
+Visual	SettingsWindow		Visuale
 Convert to Unix	GenioWindow		Converti a Unix
-Add file:	NewProject Window		Add file:
-Haiku app dir:	NewProject Window		Haiku app dir:
-Keep	GenioWindow		Mantieni
-Close File	GenioWindow		Chiudi il File
+Build commands	ProjectSettingsWindow		Build commands
+Save caret position	SettingsWindow		Salva posizione cursore

--- a/src/helpers/console_io/ConsoleIOView.cpp
+++ b/src/helpers/console_io/ConsoleIOView.cpp
@@ -152,7 +152,7 @@ ConsoleIOView::MessageReceived(BMessage* message)
 			if (fConsoleIOThread) {
 				//this should be prevented by the UI...
 				BString msg = "\n *** ";
-				msg << B_TRANSLATE("Another command is running..");
+				msg << B_TRANSLATE("Another command is running.");
 				msg << "\n";
 				
 				ConsoleOutputReceived(1, msg);

--- a/src/project/ProjectSettingsWindow.cpp
+++ b/src/project/ProjectSettingsWindow.cpp
@@ -94,7 +94,7 @@ ProjectSettingsWindow::_InitWindow()
 {
 	// "Build Commands" Box
 	fBuildCommandsBox = new BBox("BuildCommandsBox");
-	fBuildCommandsBox->SetLabel(B_TRANSLATE("Build Commands"));
+	fBuildCommandsBox->SetLabel(B_TRANSLATE("Build commands"));
 
 	fReleaseBuildCommandText = new BTextControl(B_TRANSLATE("Release build comand:"), "", nullptr);
 	fDebugBuildCommandText = new BTextControl(B_TRANSLATE("Debug build comand:"), "", nullptr);

--- a/src/ui/Editor.cpp
+++ b/src/ui/Editor.cpp
@@ -1066,8 +1066,8 @@ Editor::SetReadOnly(bool readOnly)
 	}
 	
 	if (IsModified()) {
-		BString text(B_TRANSLATE("Save changes to file"));
-		text << " \"" << Name() << "\" ?";
+		BString text(B_TRANSLATE("Save changes to file \"%filename%\"?"));
+		text.ReplaceFirst("%filename%", Name());
 
 		BAlert* alert = new BAlert(B_TRANSLATE("Save dialog"), text,
  			B_TRANSLATE("Cancel"), B_TRANSLATE("Don't save"), B_TRANSLATE("Save"),

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -1569,7 +1569,6 @@ GenioWindow::_FileSave(int32 index)
 		<< editor->Name() << "    "
 		<< length << " bytes -> "
 		<< written << " written";
-
 	_SendNotification(notification, length == written ? "FILE_SAVE" : "FILE_ERR");
 
 	return B_OK;
@@ -1854,10 +1853,8 @@ GenioWindow::_HandleExternalMoveModification(entry_ref* oldRef, entry_ref* newRe
 
 	BString text;
 	text << GenioNames::kApplicationName << ":\n";
-	text << B_TRANSLATE("File \"%file%\" was moved externally.")
-		 << "\n"
-		 << B_TRANSLATE("Do you want to ignore, close or reload it?");
-
+	text << B_TRANSLATE("File \"%file%\" was apparently moved.\n"
+		 "Do you want to ignore, close or reload it?");
 	text.ReplaceAll("%file%", oldRef->name);
 
 	BAlert* alert = new BAlert("FileMoveDialog", text,
@@ -1917,13 +1914,11 @@ GenioWindow::_HandleExternalRemoveModification(int32 index)
 
 	BString text;
 	text << GenioNames::kApplicationName << ":\n";
-	text 	<< B_TRANSLATE("File \"%file%\" was removed externally.")
-			<< "\n"
-			<< B_TRANSLATE("Do you want to keep the file or discard it?")
-			<< "\n"
-			<< B_TRANSLATE("If kept and modified, save it or it will be lost");
+	text << B_TRANSLATE("File \"%file%\" was apparently removed.\n"
+		"Do you want to keep the file or discard it?\n"
+		"If kept and modified, save it or it will be lost.");
 
-	text.ReplaceAll("%file%", fileName);
+	text.ReplaceFirst("%file%", fileName);
 
 	BAlert* alert = new BAlert("FileRemoveDialog", text,
  		B_TRANSLATE("Keep"), B_TRANSLATE("Discard"), nullptr,
@@ -1959,8 +1954,8 @@ GenioWindow::_HandleExternalStatModification(int32 index)
 
 	BString text;
 	text << GenioNames::kApplicationName << ":\n";
-	text << (B_TRANSLATE("File \"%file%\" was modified externally, reload it?"));
-	text.ReplaceAll("%file%", editor->Name());
+	text << (B_TRANSLATE("File \"%file%\" was apparently modified, reload it?"));
+	text.ReplaceFirst("%file%", editor->Name());
 
 	BAlert* alert = new BAlert("FileReloadDialog", text,
  		B_TRANSLATE("Ignore"), B_TRANSLATE("Reload"), nullptr,
@@ -1974,6 +1969,7 @@ GenioWindow::_HandleExternalStatModification(int32 index)
 		BString notification;
 		notification << "File info: " << editor->Name()
 			<< " modified externally";
+
 		_SendNotification(notification, "FILE_INFO");
 	}
 }
@@ -2142,8 +2138,8 @@ GenioWindow::_InitCentralSplit()
 												.Add(fFindWholeWordCheck)
 												.Add(fFindCaseSensitiveCheck).View());
 
-	fFindGroup->AddAction(MSG_FIND_MARK_ALL, B_TRANSLATE("Mark all"), "kIconBookmarkPen");	
-	fFindGroup->AddAction(MSG_FIND_IN_FILES, B_TRANSLATE("Find in files"), "kIconFindInFiles");
+	fFindGroup->AddAction(MSG_FIND_MARK_ALL, B_TRANSLATE("Bookmark all"), "kIconBookmarkPen");
+	fFindGroup->AddAction(MSG_FIND_IN_FILES, B_TRANSLATE("Find in project"), "kIconFindInFiles");
 	fFindGroup->AddGlue();
 	
 	fFindGroup->Hide();
@@ -2297,7 +2293,7 @@ GenioWindow::_InitActions()
 								   B_TRANSLATE("Duplicate current line"),
 								   "", "", 'K');
 	ActionManager::RegisterAction(MSG_DELETE_LINES,
-								   B_TRANSLATE("Delete lines"),
+								   B_TRANSLATE("Delete current line"),
 								   "", "", 'D');
 								   
 	ActionManager::RegisterAction(MSG_COMMENT_SELECTED_LINES,
@@ -2333,12 +2329,12 @@ GenioWindow::_InitActions()
 
 	ActionManager::RegisterAction(MSG_FIND_GROUP_TOGGLED, //MSG_FIND_GROUP_SHOW,
 								   B_TRANSLATE("Find"),
-								   B_TRANSLATE("Find toggle (closes Replace bar if open)"),
+								   B_TRANSLATE("Show/Hide find bar"),
 								   "kIconFind");
 	
 	ActionManager::RegisterAction(MSG_REPLACE_GROUP_TOGGLED, //MSG_REPLACE_GROUP_SHOW,
 								   B_TRANSLATE("Replace"),
-								   B_TRANSLATE("Replace toggle (leaves Find bar open)"),
+								   B_TRANSLATE("Show/Hide replace bar"),
 								   "kIconReplace");
 
 	
@@ -2370,12 +2366,12 @@ GenioWindow::_InitActions()
 
 	ActionManager::RegisterAction(MSG_SHOW_HIDE_PROJECTS,
 								   B_TRANSLATE("Show projects pane"),
-								   B_TRANSLATE("Show/Hide projects pane"), 
+								   B_TRANSLATE("Show/Hide projects pane"),
 								   "kIconWindow");
 								   
 	ActionManager::RegisterAction(MSG_SHOW_HIDE_OUTPUT,
-								   B_TRANSLATE("Show output panes"),
-	                               B_TRANSLATE("Show/Hide output panes"),   
+								   B_TRANSLATE("Show output pane"),
+	                               B_TRANSLATE("Show/Hide output pane"),
 								   "kIconTerminal");
 								   
 	ActionManager::RegisterAction(MSG_TOGGLE_TOOLBAR,
@@ -2401,14 +2397,14 @@ GenioWindow::_InitActions()
 								  "kIconDebug");
 								  
 	ActionManager::RegisterAction(MSG_BUFFER_LOCK, 
-								  B_TRANSLATE("Read only"),
-								  B_TRANSLATE("Set buffer read-only"), "kIconUnlocked");
+								  B_TRANSLATE("Read-only"),
+								  B_TRANSLATE("Make file read-only"), "kIconUnlocked");
 								  
 	ActionManager::RegisterAction(MSG_FILE_PREVIOUS_SELECTED, "",
-						          B_TRANSLATE("Select previous file"), "kIconBack_1");
+						          B_TRANSLATE("Switch to previous file"), "kIconBack_1");
 								  
 	ActionManager::RegisterAction(MSG_FILE_NEXT_SELECTED, "", 
-								  B_TRANSLATE("Select next file"), "kIconForward_2");
+								  B_TRANSLATE("Switch to next file"), "kIconForward_2");
 								   
 	// Find Panel
 	ActionManager::RegisterAction(MSG_FIND_NEXT,
@@ -2570,13 +2566,14 @@ GenioWindow::_InitMenu()
 	ActionManager::SetEnabled(MSG_GOTO_LINE, false);
 
 	fBookmarksMenu = new BMenu(B_TRANSLATE("Bookmark"));
-	fBookmarksMenu->AddItem(fBookmarkToggleItem = new BMenuItem(B_TRANSLATE("Toggle"),
-		new BMessage(MSG_BOOKMARK_TOGGLE)));
-	fBookmarksMenu->AddItem(fBookmarkClearAllItem = new BMenuItem(B_TRANSLATE("Clear all"),
-		new BMessage(MSG_BOOKMARK_CLEAR_ALL)));
-	fBookmarksMenu->AddItem(fBookmarkGoToNextItem = new BMenuItem(B_TRANSLATE("Go to next"),
-		new BMessage(MSG_BOOKMARK_GOTO_NEXT), 'N', B_CONTROL_KEY));
-	fBookmarksMenu->AddItem(fBookmarkGoToPreviousItem = new BMenuItem(B_TRANSLATE("Go to previous"),
+	fBookmarksMenu->AddItem(fBookmarkToggleItem = new BMenuItem(B_TRANSLATE_COMMENT("Toggle",
+		"Bookmark menu"), new BMessage(MSG_BOOKMARK_TOGGLE)));
+	fBookmarksMenu->AddItem(fBookmarkClearAllItem = new BMenuItem(B_TRANSLATE_COMMENT("Clear all",
+		"Bookmark menu"), new BMessage(MSG_BOOKMARK_CLEAR_ALL)));
+	fBookmarksMenu->AddItem(fBookmarkGoToNextItem = new BMenuItem(B_TRANSLATE_COMMENT("Next",
+		"Bookmark menu"), new BMessage(MSG_BOOKMARK_GOTO_NEXT), 'N', B_CONTROL_KEY));
+	fBookmarksMenu->AddItem(fBookmarkGoToPreviousItem = new BMenuItem(B_TRANSLATE_COMMENT(
+		"Previous", "Bookmark menu"),
 		new BMessage(MSG_BOOKMARK_GOTO_PREVIOUS),'P', B_CONTROL_KEY));
 
 	fBookmarksMenu->SetEnabled(false);
@@ -2640,49 +2637,58 @@ GenioWindow::_InitMenu()
 	fMenuBar->AddItem(projectMenu);
 
 	fGitMenu = new BMenu(B_TRANSLATE("Git"));
-	fGitMenu->AddItem(fGitBranchItem = new BMenuItem(B_TRANSLATE("Branch"), nullptr));
+	fGitMenu->AddItem(fGitBranchItem = new BMenuItem(B_TRANSLATE_COMMENT("Branch",
+		"The git command"), nullptr));
 	BMessage* git_branch_message = new BMessage(MSG_GIT_COMMAND);
 	git_branch_message->AddString("command", "branch");
 	fGitBranchItem->SetMessage(git_branch_message);
 
-	fGitMenu->AddItem(fGitLogItem = new BMenuItem(B_TRANSLATE("Log"), nullptr));
+	fGitMenu->AddItem(fGitLogItem = new BMenuItem(B_TRANSLATE_COMMENT("Log",
+		"The git command"), nullptr));
 	BMessage* git_log_message = new BMessage(MSG_GIT_COMMAND);
 	git_log_message->AddString("command", "log");
 	fGitLogItem->SetMessage(git_log_message);
 
-	fGitMenu->AddItem(fGitPullItem = new BMenuItem(B_TRANSLATE("Pull"), nullptr));
+	fGitMenu->AddItem(fGitPullItem = new BMenuItem(B_TRANSLATE_COMMENT("Pull",
+		"The git command"), nullptr));
 	BMessage* git_pull_message = new BMessage(MSG_GIT_COMMAND);
 	git_pull_message->AddString("command", "pull");
 	fGitPullItem->SetMessage(git_pull_message);
 
-	fGitMenu->AddItem(fGitStatusItem = new BMenuItem(B_TRANSLATE("Status"), nullptr));
+	fGitMenu->AddItem(fGitStatusItem = new BMenuItem(B_TRANSLATE_COMMENT("Status",
+		"The git command"), nullptr));
 	BMessage* git_status_message = new BMessage(MSG_GIT_COMMAND);
 	git_status_message->AddString("command", "status");
 	fGitStatusItem->SetMessage(git_status_message);
 
-	fGitMenu->AddItem(fGitShowConfigItem = new BMenuItem(B_TRANSLATE("Show config"), nullptr));
+	fGitMenu->AddItem(fGitShowConfigItem = new BMenuItem(B_TRANSLATE_COMMENT("Show config",
+		"The git command"), nullptr));
 	BMessage* git_config_message = new BMessage(MSG_GIT_COMMAND);
 	git_config_message->AddString("command", "config --list");
 	fGitShowConfigItem->SetMessage(git_config_message);
 
-	fGitMenu->AddItem(fGitTagItem = new BMenuItem(B_TRANSLATE("Tag"), nullptr));
+	fGitMenu->AddItem(fGitTagItem = new BMenuItem(B_TRANSLATE_COMMENT("Tag",
+		"The git command"), nullptr));
 	BMessage* git_tag_message = new BMessage(MSG_GIT_COMMAND);
 	git_tag_message->AddString("command", "tag");
 	fGitTagItem->SetMessage(git_tag_message);
 
 	fGitMenu->AddSeparatorItem();
 
-	fGitMenu->AddItem(fGitLogOnelineItem = new BMenuItem(B_TRANSLATE("Log (oneline)"), nullptr));
+	fGitMenu->AddItem(fGitLogOnelineItem = new BMenuItem(B_TRANSLATE_COMMENT("Log (oneline)",
+		"The git command"), nullptr));
 	BMessage* git_log_oneline_message = new BMessage(MSG_GIT_COMMAND);
 	git_log_oneline_message->AddString("command", "log --oneline --decorate");
 	fGitLogOnelineItem->SetMessage(git_log_oneline_message);
 
-	fGitMenu->AddItem(fGitPullRebaseItem = new BMenuItem(B_TRANSLATE("Pull (rebase)"), nullptr));
+	fGitMenu->AddItem(fGitPullRebaseItem = new BMenuItem(B_TRANSLATE_COMMENT("Pull (rebase)",
+		"The git command"), nullptr));
 	BMessage* git_pull_rebase_message = new BMessage(MSG_GIT_COMMAND);
 	git_pull_rebase_message->AddString("command", "pull --rebase");
 	fGitPullRebaseItem->SetMessage(git_pull_rebase_message);
 
-	fGitMenu->AddItem(fGitStatusShortItem = new BMenuItem(B_TRANSLATE("Status (short)"), nullptr));
+	fGitMenu->AddItem(fGitStatusShortItem = new BMenuItem(B_TRANSLATE_COMMENT("Status (short)",
+		"The git command"), nullptr));
 	BMessage* git_status_short_message = new BMessage(MSG_GIT_COMMAND);
 	git_status_short_message->AddString("command", "status --short");
 	fGitStatusShortItem->SetMessage(git_status_short_message);
@@ -2745,7 +2751,7 @@ GenioWindow::_InitToolbar()
 	
 	ActionManager::AddItem(MSG_FILE_CLOSE, fToolBar);
 	
-	fToolBar->AddAction(MSG_FILE_MENU_SHOW, B_TRANSLATE("Indexed file list"), "kIconFileList");
+	fToolBar->AddAction(MSG_FILE_MENU_SHOW, B_TRANSLATE("Open files list"), "kIconFileList");
 	
 	
 	ActionManager::SetEnabled(MSG_FIND_GROUP_TOGGLED, false);
@@ -3176,12 +3182,10 @@ GenioWindow::_ProjectFileDelete()
 
 	entry.GetName(name);
 
-	BString text;
-	text
-		 << B_TRANSLATE("Deleting item:")
-		 << " \"" << name << "\"" << ".\n\n"
-		 << B_TRANSLATE("After deletion the item will be lost.") << "\n"
-		 << B_TRANSLATE("Do you really want to delete it?") << "\n";
+	BString text(B_TRANSLATE("Deleting item: \"%name%\".\n\n"
+		"After deletion, the item will be lost.\n"
+		"Do you really want to delete it?"));
+	text.ReplaceFirst("%name%", name);
 
 	BAlert* alert = new BAlert(B_TRANSLATE("Delete dialog"),
 		text.String(),
@@ -3208,8 +3212,10 @@ GenioWindow::_ProjectFileDelete()
 			else
 				status = entry.Remove();
 			if (status != B_OK) {
-				OKAlert("Delete item", BString("Could not delete ") << name << "\n\n" << ::strerror(status),
-					B_WARNING_ALERT);
+				BString text(B_TRANSLATE("Could not delete \"%name%\".\n\n"));
+				text << ::strerror(status);
+				text.ReplaceFirst("%name%", name);
+				OKAlert("Delete item", text.String(), B_WARNING_ALERT);
 				LogError("Could not delete %s (%s)", name, ::strerror(status));
 			}
 		}
@@ -3424,12 +3430,12 @@ GenioWindow::_ShowCurrentItemInTracker()
 			commandLine.SetToFormat("/bin/open %s", EscapeQuotesWrap(directoryPath.Path()).String());
 			returnStatus = system(commandLine);
 		} else {
-			notification << "An error occurred while showing item in Tracker:" << directoryPath.Path();
-			_SendNotification(notification, "PROJ_SHOW");	
+			notification << "An error occurred when showing an item in Tracker: " << directoryPath.Path();
+			_SendNotification(notification, "PROJ_SHOW");
 		}
 	} else {
 		notification << "An error occurred while retrieving parent directory of " << itemPath;
-		_SendNotification(notification, "PROJ_TRACK");	
+		_SendNotification(notification, "PROJ_TRACK");
 	}
 	return returnStatus == 0 ? B_OK : errno;
 }

--- a/src/ui/ProjectsFolderBrowser.cpp
+++ b/src/ui/ProjectsFolderBrowser.cpp
@@ -39,7 +39,7 @@ ProjectsFolderBrowser::ProjectsFolderBrowser():
 
 	fCloseProjectMenuItem = new BMenuItem(B_TRANSLATE("Close project"),
 		new BMessage(MSG_PROJECT_MENU_CLOSE));
-	fSetActiveProjectMenuItem = new BMenuItem(B_TRANSLATE("Set Active"),
+	fSetActiveProjectMenuItem = new BMenuItem(B_TRANSLATE("Set active"),
 		new BMessage(MSG_PROJECT_MENU_SET_ACTIVE));
 		
 	fFileNewProjectMenuItem = new TemplatesMenu(this, B_TRANSLATE("New"),
@@ -179,8 +179,9 @@ ProjectsFolderBrowser::_UpdateNode(BMessage* message)
 					// It seems not possible to track the project folder to the new
 					// location outside of the watched path. So we close the project 
 					// and warn the user
-					auto alert = new BAlert("ProjectFolderChanged",
-						B_TRANSLATE("The project folder has been deleted or moved to another location and it will be closed and unloaded from the workspace."),
+					auto alert = new BAlert("ProjectFolderChanged", B_TRANSLATE(
+						"The project folder has been deleted or moved to another location "
+						"and it will be closed and unloaded from the workspace."),
 						B_TRANSLATE("OK"), NULL, NULL,
 						B_WIDTH_AS_USUAL, B_OFFSET_SPACING, B_WARNING_ALERT);
 						alert->Go();

--- a/src/ui/SettingsWindow.cpp
+++ b/src/ui/SettingsWindow.cpp
@@ -1056,10 +1056,10 @@ SettingsWindow::_PageGeneralViewStartup()
 		B_TRANSLATE("Reload files"), new BMessage(MSG_REOPEN_FILES_TOGGLED));
 
 	fShowProjectsPanes = new BCheckBox("ShowProjectsPanes",
-		B_TRANSLATE("Show projects panes"), new BMessage(MSG_SHOW_PROJECTS_PANES_TOGGLED));
+		B_TRANSLATE("Show projects pane"), new BMessage(MSG_SHOW_PROJECTS_PANES_TOGGLED));
 
 	fShowOutputPanes = new BCheckBox("ShowOutputPanes",
-		B_TRANSLATE("Show output panes"), new BMessage(MSG_SHOW_OUTPUT_PANES_TOGGLED));
+		B_TRANSLATE("Show output pane"), new BMessage(MSG_SHOW_OUTPUT_PANES_TOGGLED));
 
 	fShowToolBar = new BCheckBox("ShowToolBar",
 		B_TRANSLATE("Show toolbar"), new BMessage(MSG_SHOW_TOOLBAR_TOGGLED));
@@ -1089,7 +1089,7 @@ SettingsWindow::_PageNotificationsView()
 	fNotificationsBox->SetLabel(B_TRANSLATE("Notifications"));
 
 	fEnableNotifications = new BCheckBox("EnableNotifications",
-		B_TRANSLATE("Enable Notifications"), new BMessage(MSG_ENABLE_NOTIFICATIONS_TOGGLED));
+		B_TRANSLATE("Enable notifications"), new BMessage(MSG_ENABLE_NOTIFICATIONS_TOGGLED));
 
 	BView* view = BGroupLayoutBuilder(B_VERTICAL, 0)
 		.Add(BLayoutBuilder::Grid<>(fNotificationsBox)
@@ -1304,9 +1304,8 @@ SettingsWindow::_UpdateText()
 	BString text;
 
 	text << fControlsDone << "/" << fControlsCount;
-	text <<  " " << B_TRANSLATE("Controls loaded.");
-	text << " " << B_TRANSLATE("Modifications") << " " << fModifiedList->CountItems();
-	text <<  ",\t" << B_TRANSLATE("applied") << " " << fAppliedModifications;
+	text << " " << "Controls loaded. Modifications " << fModifiedList->CountItems();
+	text << ", applied " << fAppliedModifications;
 	fStatusBar->SetText(text.String());
 }
 
@@ -1315,12 +1314,10 @@ SettingsWindow::_UpdateTrailing()
 {
 	BString text;
 
-	text << B_TRANSLATE("Set for app ver: ")
-		 << fWindowSettingsFile->FindString("app_version") << ",\t";
+	text << "Set for app ver: " << fWindowSettingsFile->FindString("app_version") << ",\t";
 
-	BString option = fUseCount == 1	? B_TRANSLATE("time")
-										: B_TRANSLATE("times");
-	text << B_TRANSLATE("tuned ") << fUseCount << " " << option;
+	BString option = fUseCount == 1	? "time" : "times";
+	text << "tuned " << fUseCount << " " << option;
 
 	fStatusBar->SetTrailingText(text.String());
 }


### PR DESCRIPTION
Using variables in a complete sentence and then ReplaceFirst() those variables makes it easier to translate, instead of concatenating short strings and variables via "<<". It's also more flexible for special ordering of 'exotic' languages.

Added a few B_TRANSLATE_COMMENT where applicable to help the translators.

Details:
* Changed tooltip for kIconFindInFiles icon to "Find in project", because it with "Find in files" you may think if only searches the files currently open in the editor.

* Renamed "Edit | Delete lines" to "Edit | Delete current line", because it will always only delete the one line the cursor is on.

* Replaced Find icon tooltip: "Find toggle (closes Replace bar if open)" to "Show/Hide find bar" The tool tip appears to be too specific. Can be confusing if there's no Replace bar open at the time. The user will quickly learn what clicking the icon does...

* Similar for the Replace icon tooltip.

* Removed translation macros for the status bar of the Settings window. I assume these are only for the beta versions of Genio and are for debugging purposes? Can revert, of course...