### PR TITLE
Have _FilesNeedSave() return how many files were modified

### DIFF
--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.Genio	1556747924
+1	English	application/x-vnd.Genio	3960022605
 Copy	GenioWindow		Copy
 Enable brace matching	SettingsWindow		Enable brace matching
 Clear	ConsoleIOView		Clear
@@ -183,6 +183,7 @@ Show config	GenioWindow	The git command	Show config
 Projects	GenioWindow		Projects
 Go to implementation	GenioWindow		Go to implementation
 Run target	GenioWindow		Run target
+{0, plural,one{A file was modified. Do you want to save the changes before quitting?}other{# files were modified. Do you want to save the changes before quitting?}}	GenioWindow		{0, plural,one{A file was modified. Do you want to save the changes before quitting?}other{# files were modified. Do you want to save the changes before quitting?}}
 New	ProjectsFolderBrowser		New
 Could not create a new file	GenioWindow		Could not create a new file
 Browse…	SettingsWindow		Browse…
@@ -223,7 +224,6 @@ Genio uses:\nScintilla lib\nCopyright 1998-2003 by Neil Hodgson <neilh@scintilla
 Open project	GenioWindow		Open project
 Ignore	GenioApp		Ignore
 Edit	GenioWindow		Edit
-There are modified files, do you want to save changes before quitting?	GenioWindow		There are modified files, do you want to save changes before quitting?
 Deleting item: \"%name%\".\n\nAfter deletion, the item will be lost.\nDo you really want to delete it?	GenioWindow		Deleting item: \"%name%\".\n\nAfter deletion, the item will be lost.\nDo you really want to delete it?
 Find next	GenioWindow		Find next
 Notifications	SettingsWindow		Notifications

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -26,6 +26,7 @@
 #include <Resources.h>
 #include <Roster.h>
 #include <SeparatorView.h>
+#include <StringFormat.h>
 #include <StringItem.h>
 #include <NodeInfo.h>
 
@@ -1099,9 +1100,14 @@ bool
 GenioWindow::QuitRequested()
 {
 	// Is there any modified file?
-	if (_FilesNeedSave()) {
-		BAlert* alert = new BAlert("QuitAndSaveDialog",
-	 		B_TRANSLATE("There are modified files, do you want to save changes before quitting?"),
+	int32 count = _FilesNeedSave();
+	if (count > 0) {
+		BString text = "";
+		static BStringFormat format(B_TRANSLATE("{0, plural,"
+			"one{A file was modified. Do you want to save the changes before quitting?}"
+			"other{Some files were modified. Do you want to save the changes before quitting?}}"));
+		format.Format(text, count);
+		BAlert* alert = new BAlert("QuitAndSaveDialog", text,
  			B_TRANSLATE("Cancel"), B_TRANSLATE("Don't save"), B_TRANSLATE("Save"),
  			B_WIDTH_AS_USUAL, B_OFFSET_SPACING, B_WARNING_ALERT);
   
@@ -1641,17 +1647,17 @@ GenioWindow::_FileSaveAs(int32 selection, BMessage* message)
 	return B_OK;
 }
 
-bool
+int32
 GenioWindow::_FilesNeedSave()
 {
+	int32 count = 0;
 	for (int32 index = 0; index < fTabManager->CountTabs(); index++) {
 		Editor* editor = fTabManager->EditorAt(index);
-		if (editor->IsModified()) {
-			return true;
-		}
+		if (editor->IsModified())
+			count++;
 	}
 
-	return false;
+	return count;
 }
 
 void
@@ -3775,7 +3781,7 @@ GenioWindow::_UpdateSavepointChange(int32 index, const BString& caller)
 
 	// editor is modified by _FilesNeedSave so it should be the last
 	// or reload editor pointer
-	bool filesNeedSave = _FilesNeedSave();
+	bool filesNeedSave = (_FilesNeedSave() > 0 ? true : false);
 	ActionManager::SetEnabled(MSG_FILE_SAVE_ALL, filesNeedSave);
 }
 

--- a/src/ui/GenioWindow.h
+++ b/src/ui/GenioWindow.h
@@ -79,7 +79,7 @@ private:
 			status_t			_FileSave(int32	index);
 			void				_FileSaveAll();
 			status_t			_FileSaveAs(int32 selection, BMessage* message);
-			bool				_FilesNeedSave();
+			int32				_FilesNeedSave();
 			void				_FindGroupShow(bool show);
 			int32				_FindMarkAll(const BString text);
 			void				_FindNext(const BString& strToFind, bool backwards);


### PR DESCRIPTION
By not returning a simple bool, but the count of modified files, we can correctly pluralize the "Save modified files" BAlert.