### PR TITLE
Fix project tree icons and editor navmenu button scaling

### DIFF
--- a/src/project/ProjectItem.cpp
+++ b/src/project/ProjectItem.cpp
@@ -117,6 +117,7 @@ ProjectItem::DrawItem(BView* owner, BRect bounds, bool complete)
 	auto icon = IconCache::GetIcon(GetSourceItem()->Path());
 
 	float iconSize = be_control_look->ComposeIconSize(B_MINI_ICON).Height();
+	iconSize = iconSize > B_LARGE_ICON ? B_LARGE_ICON : iconSize;
 	BPoint iconStartingPoint(bounds.left + 4.0f, bounds.top  + (bounds.Height() - iconSize) / 2.0f);	
 
 	fTextRect.top = bounds.top - 0.5f;

--- a/src/project/ProjectItem.cpp
+++ b/src/project/ProjectItem.cpp
@@ -118,7 +118,7 @@ ProjectItem::DrawItem(BView* owner, BRect bounds, bool complete)
 
 	float iconSize = be_control_look->ComposeIconSize(B_MINI_ICON).Height();
 	iconSize = iconSize > B_LARGE_ICON ? B_LARGE_ICON : iconSize;
-	BPoint iconStartingPoint(bounds.left + 4.0f, bounds.top  + (bounds.Height() - iconSize) / 2.0f);	
+	BPoint iconStartingPoint(bounds.left + 4.0f, bounds.top  + (bounds.Height() - iconSize) / 2.0f);
 
 	fTextRect.top = bounds.top - 0.5f;
 	fTextRect.left = iconStartingPoint.x + iconSize + be_control_look->DefaultLabelSpacing();
@@ -132,17 +132,7 @@ ProjectItem::DrawItem(BView* owner, BRect bounds, bool complete)
 
 	// Check if there is an InitRename request and show a TextControl
 	if (fInitRename) {
-		if (fTextControl == nullptr) {
-			fTextControl = new TemporaryTextControl(fTextRect, "RenameTextWidget", "", 
-												Text(), fMessage, this,
-												B_FOLLOW_NONE);
-			owner->AddChild(fTextControl);
-			fTextControl->TextView()->SetAlignment(B_ALIGN_LEFT);
-			fTextControl->SetDivider(0);
-			fTextControl->TextView()->SelectAll();
-			fTextControl->TextView()->ResizeBy(0,-3);
-		}
-		fTextControl->MakeFocus();
+		_DrawTextWidget(owner);
 	} else {
 		// Draw string at the right of the icon
 		owner->SetDrawingMode(B_OP_COPY);
@@ -150,7 +140,7 @@ ProjectItem::DrawItem(BView* owner, BRect bounds, bool complete)
 							bounds.top + BaselineOffset());
 		owner->DrawString(Text());
 		owner->Sync();
-		
+
 		if (fFirstTimeRendered) {
 			owner->Invalidate();
 			fFirstTimeRendered = false;
@@ -194,6 +184,24 @@ ProjectItem::CommitRename()
 	}
 	fInitRename = false;
 }
+
+
+void
+ProjectItem::_DrawTextWidget(BView* owner)
+{
+	if (fTextControl == nullptr) {
+		fTextControl = new TemporaryTextControl(fTextRect, "RenameTextWidget",
+											"", Text(), fMessage, this,
+											B_FOLLOW_NONE);
+		owner->AddChild(fTextControl);
+		fTextControl->TextView()->SetAlignment(B_ALIGN_LEFT);
+		fTextControl->SetDivider(0);
+		fTextControl->TextView()->SelectAll();
+		fTextControl->TextView()->ResizeBy(0, -3);
+	}
+	fTextControl->MakeFocus();
+}
+
 
 void
 ProjectItem::_DestroyTextWidget()

--- a/src/project/ProjectItem.cpp
+++ b/src/project/ProjectItem.cpp
@@ -117,7 +117,6 @@ ProjectItem::DrawItem(BView* owner, BRect bounds, bool complete)
 	auto icon = IconCache::GetIcon(GetSourceItem()->Path());
 
 	float iconSize = be_control_look->ComposeIconSize(B_MINI_ICON).Height();
-	iconSize = iconSize > B_LARGE_ICON ? B_LARGE_ICON : iconSize;
 	BPoint iconStartingPoint(bounds.left + 4.0f, bounds.top  + (bounds.Height() - iconSize) / 2.0f);
 
 	fTextRect.top = bounds.top - 0.5f;

--- a/src/project/ProjectItem.h
+++ b/src/project/ProjectItem.h
@@ -38,6 +38,8 @@ private:
 	BMessage*		fMessage;
 	BTextControl	*fTextControl;
 	
+	void			_DrawIcon(BView* owner);
+	void			_DrawTextWidget(BView* owner);
 	void			_DestroyTextWidget();
 };
 

--- a/src/ui/EditorStatusView.cpp
+++ b/src/ui/EditorStatusView.cpp
@@ -51,6 +51,10 @@ StatusView::StatusView(Editor* editor)	:
 			fNavigationPressed(false),
 			fNavigationButtonWidth(B_H_SCROLL_BAR_HEIGHT)
 {
+	BScrollBar* scrollBar = ScrollView()->ScrollBar(B_HORIZONTAL);
+	if (scrollBar != NULL)
+		fNavigationButtonWidth = scrollBar->Bounds().Height() + 1;
+
 	memset(fCellWidth, 0, sizeof(fCellWidth));
 
 	SetFont(be_plain_font);

--- a/src/ui/EditorStatusView.h
+++ b/src/ui/EditorStatusView.h
@@ -62,7 +62,7 @@ private:
 			BString			fCellText[kStatusCellCount];
 			float			fCellWidth[kStatusCellCount];
 			bool			fNavigationPressed;
-	const	float			fNavigationButtonWidth;
+			float			fNavigationButtonWidth;
 			
 			static BPopUpMenu*		sMenu;
 };

--- a/src/ui/IconCache.cpp
+++ b/src/ui/IconCache.cpp
@@ -9,6 +9,7 @@
 #define DIR_FILETYPE "application/x-vnd.Be-directory"
 #define FILE_FILETYPE "application/octet-stream"
 
+
 IconCache IconCache::instance;
 
 IconCache::IconCache()
@@ -39,15 +40,11 @@ IconCache::GetIcon(entry_ref *ref)
 		return it->second;
 	} else {
 		LogTrace("IconCache: could not find an icon in cache for %s",mimeType);
-		// TODO: Seems like icons bigger than 32x32 don't work correctly.
-		// for now cap the max size to 32x32.
 		BSize composedSize = be_control_look->ComposeIconSize(B_MINI_ICON);
-		float cappedWidth = composedSize.Width() > B_LARGE_ICON ? B_LARGE_ICON : composedSize.Width();
-		float cappedHeight = composedSize.Height() > B_LARGE_ICON ? B_LARGE_ICON : composedSize.Height(); 
-		BRect rect(0, 0, cappedWidth, cappedHeight);
+		BRect rect(0, 0, composedSize.IntegerWidth() - 1, composedSize.IntegerHeight() - 1);
 		BBitmap *icon = new BBitmap(rect, B_RGBA32);
-		icon_size iconSize = (icon_size)(icon->Bounds().Width()-1);
-		status_t status = nodeInfo.GetTrackerIcon(icon, iconSize);
+		icon_size iconSize = (icon_size)(icon->Bounds().IntegerWidth() - 1);
+		status_t status = nodeInfo.GetTrackerIcon(icon, (icon_size)iconSize);
 		instance.cache.emplace(mimeType, icon);
 		LogTrace("IconCache: GetTrackerIcon returned - %d", status);
 		return icon;

--- a/src/ui/IconCache.cpp
+++ b/src/ui/IconCache.cpp
@@ -39,7 +39,12 @@ IconCache::GetIcon(entry_ref *ref)
 		return it->second;
 	} else {
 		LogTrace("IconCache: could not find an icon in cache for %s",mimeType);
-		BRect rect(BPoint(0, 0), be_control_look->ComposeIconSize(B_MINI_ICON));
+		// TODO: Seems like icons bigger than 32x32 don't work correctly.
+		// for now cap the max size to 32x32.
+		BSize composedSize = be_control_look->ComposeIconSize(B_MINI_ICON);
+		float cappedWidth = composedSize.Width() > B_LARGE_ICON ? B_LARGE_ICON : composedSize.Width();
+		float cappedHeight = composedSize.Height() > B_LARGE_ICON ? B_LARGE_ICON : composedSize.Height(); 
+		BRect rect(0, 0, cappedWidth, cappedHeight);
 		BBitmap *icon = new BBitmap(rect, B_RGBA32);
 		icon_size iconSize = (icon_size)(icon->Bounds().Width()-1);
 		status_t status = nodeInfo.GetTrackerIcon(icon, iconSize);


### PR DESCRIPTION
Fix Project tree icons not drawing correctly at font sizes > 25.
Also fix scaling of the navmenu in the editor status view