### PR TITLE
Fix LSP lock on close

### DIFF
--- a/src/lsp-client/LSPClient.cpp
+++ b/src/lsp-client/LSPClient.cpp
@@ -86,6 +86,25 @@ LSPClient::Init(const char *argv[])
 	return stat;
 }
 
+status_t
+LSPClient::IsProcessAlive()
+{
+	thread_info info;
+	return get_thread_info(fChildpid, &info);	
+}
+
+status_t
+LSPClient::InterruptExternal()
+{
+	status_t status = IsProcessAlive();
+	if (status == B_OK) {
+		status = send_signal(-fChildpid, SIGTERM);
+		return wait_for_thread_etc(fChildpid, 0, 4000, &status);
+	}
+
+	return status;
+}
+
 void	
 LSPClient::Close()
 {

--- a/src/lsp-client/LSPClient.h
+++ b/src/lsp-client/LSPClient.h
@@ -33,6 +33,8 @@ public:
 
   pid_t GetChildPid();
   
+  status_t IsProcessAlive();
+  status_t InterruptExternal();
 
 private:
   BLocker fWriteLock;

--- a/src/lsp-client/LSPClientWrapper.cpp
+++ b/src/lsp-client/LSPClientWrapper.cpp
@@ -83,12 +83,11 @@ LSPClientWrapper::Create(const char *uri)
   return fOnEroor.load();
 }
 
-int32 
-LSPClientWrapper::thread_func(void *data)
+int32
+LSPClientWrapper::thread_func(void* data)
 {
-   LSPClientWrapper* wrap = (LSPClientWrapper*)data;
-	if (wrap->loop(*wrap) == -1)
-	{
+	LSPClientWrapper* wrap = (LSPClientWrapper*) data;
+	if (wrap->loop(*wrap) == -1) {
 		wrap->fOnEroor.store(true);
 		wrap->fInitialized.store(false);
 		wrap->Close();
@@ -96,23 +95,24 @@ LSPClientWrapper::thread_func(void *data)
 	return 0;
 }
 
-bool	
+bool
 LSPClientWrapper::Dispose()
 {
 	if (!fInitialized) {
-    	return true;
-    }
+		return true;
+	}
 
-    for(auto& m: fTextDocs)
-		LogError("LSPClientWrapper::Dispose() still textDocument registered! [%s]", m.second->GetFilenameURI().c_str());
-    
+	for (auto& m : fTextDocs)
+		LogError("LSPClientWrapper::Dispose() still textDocument registered! [%s]",
+			m.second->GetFilenameURI().c_str());
+
 	Shutdown();
 	int tries = 4;
 	while (fInitialized.load() && tries--) {
 		LogDebug("Waiting for shutdown...(%d)\n", tries);
 		usleep(100000);
 	}
-	if (tries == 0) { 
+	if (tries == 0) {
 		InterruptExternal();
 	} else {
 		Exit();
@@ -121,7 +121,7 @@ LSPClientWrapper::Dispose()
 	kill_thread(fReaderThread);
 	return true;
 }
-		
+
 LSPTextDocument*	
 LSPClientWrapper::_DocumentByURI(const std::string& uri)
 {

--- a/src/lsp-client/LSPClientWrapper.h
+++ b/src/lsp-client/LSPClientWrapper.h
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <thread>
 #include <optional>
+#include <OS.h>
 
 class  LSPTextDocument;
 struct TextDocumentContentChangeEvent;
@@ -91,6 +92,8 @@ public:
 
 private:
 
+	static int32 thread_func(void *data);
+
 	LSPTextDocument*	_DocumentByURI(const std::string& uri);
 
 	typedef std::map<std::string, LSPTextDocument*> MapFile;
@@ -98,8 +101,9 @@ private:
 	MapFile	fTextDocs;
 
 	std::atomic<bool> fInitialized;
+	std::atomic<bool> fOnEroor;
 
-	std::thread fReaderThread;
+	thread_id	fReaderThread;
 	
 	std::string fAllCommitCharacters;
 	std::string fTriggerCharacters;


### PR DESCRIPTION
Removed std::thread in favour of haiku threads. This way it's possible to kill the lsp reading thread even if locked on the same BLooper managing the quit request.