### PR TITLE
Feature/improve project browser

### DIFF
--- a/src/project/ProjectFolder.cpp
+++ b/src/project/ProjectFolder.cpp
@@ -131,6 +131,7 @@ ProjectFolder::GetBuildMode()
 	return fBuildMode;
 }
 
+
 void
 ProjectFolder::SetBuildCommand(BString const& command, BuildMode mode)
 {
@@ -144,9 +145,12 @@ ProjectFolder::SetBuildCommand(BString const& command, BuildMode mode)
 BString const
 ProjectFolder::GetBuildCommand()
 {
-	if (fBuildMode == BuildMode::ReleaseMode)
-		return fSettings->GetString("project_release_build_command", "");
-	else
+	if (fBuildMode == BuildMode::ReleaseMode) {
+		BString build = fSettings->GetString("project_release_build_command", "");
+		if (build == "")
+			build = fGuessedBuildCommand;
+		return build;
+	} else
 		return fSettings->GetString("project_debug_build_command", "");
 }
 
@@ -164,9 +168,12 @@ ProjectFolder::SetCleanCommand(BString const& command, BuildMode mode)
 BString const
 ProjectFolder::GetCleanCommand()
 {
-	if (fBuildMode == BuildMode::ReleaseMode)
-		return fSettings->GetString("project_release_clean_command", "");
-	else
+	if (fBuildMode == BuildMode::ReleaseMode) {
+		BString clean = fSettings->GetString("project_release_clean_command", "");
+		if (clean == "")
+			clean = fGuessedCleanCommand;
+		return clean;
+	} else
 		return fSettings->GetString("project_debug_clean_command", "");
 }
 
@@ -250,4 +257,13 @@ bool
 ProjectFolder::ExcludeSettingsOnGit()
 {
 	return fSettings->GetBool("exclude_settings_git", false);
+}
+
+
+void
+ProjectFolder::SetGuessedBuilder(const BString& string)
+{
+	fGuessedBuildCommand = string;
+	fGuessedCleanCommand = string;
+	fGuessedCleanCommand.Append(" clean");
 }

--- a/src/project/ProjectFolder.cpp
+++ b/src/project/ProjectFolder.cpp
@@ -11,8 +11,6 @@
 #include <OutlineListView.h>
 #include <Path.h>
 
-#include <stdexcept>
-
 #include "LSPProjectWrapper.h"
 #include "GenioNamespace.h"
 #include "GSettings.h"
@@ -26,7 +24,7 @@ SourceItem::SourceItem(BString const& path)
 {
 	BPath _path(path);
 	fName = _path.Leaf();
-	
+
 	BEntry entry(path);
 	if (entry.IsDirectory())
 		fType = SourceItemType::FolderItem;
@@ -50,7 +48,7 @@ SourceItem::Rename(BString const& path)
 
 
 ProjectFolder::ProjectFolder(BString const& path)
-	: 
+	:
 	SourceItem(path),
 	fActive(false),
 	fBuildMode(BuildMode::ReleaseMode),
@@ -59,7 +57,7 @@ ProjectFolder::ProjectFolder(BString const& path)
 {
 	fProjectFolder = this;
 	fType = SourceItemType::ProjectFolderItem;
-	
+
 	fLSPProjectWrapper = new LSPProjectWrapper(fPath.String());
 }
 
@@ -127,8 +125,8 @@ ProjectFolder::SetBuildMode(BuildMode mode)
 
 
 BuildMode
-ProjectFolder::GetBuildMode() 
-{ 
+ProjectFolder::GetBuildMode()
+{
 	fBuildMode = (BuildMode)fSettings->GetInt32("build_mode", BuildMode::ReleaseMode);
 	return fBuildMode;
 }
@@ -145,7 +143,7 @@ ProjectFolder::SetBuildCommand(BString const& command, BuildMode mode)
 
 BString const
 ProjectFolder::GetBuildCommand()
-{	
+{
 	if (fBuildMode == BuildMode::ReleaseMode)
 		return fSettings->GetString("project_release_build_command", "");
 	else
@@ -172,7 +170,7 @@ ProjectFolder::GetCleanCommand()
 		return fSettings->GetString("project_debug_clean_command", "");
 }
 
-	
+
 void
 ProjectFolder::SetExecuteArgs(BString const& args, BuildMode mode)
 {

--- a/src/project/ProjectFolder.h
+++ b/src/project/ProjectFolder.h
@@ -84,13 +84,15 @@ public:
 	void						ExcludeSettingsOnGit(bool enabled);
 	bool						ExcludeSettingsOnGit();
 
+	void						SetGuessedBuilder(const BString& string);
+
 	LSPProjectWrapper*			GetLSPClient() { return fLSPProjectWrapper; }
 
 private:
 	bool						fActive;
 	BuildMode					fBuildMode;
-	BString						fTarget;
-	BString						fBuildCommand;
+	BString						fGuessedBuildCommand;
+	BString						fGuessedCleanCommand;
 	LSPProjectWrapper*			fLSPProjectWrapper;
 	GSettings*					fSettings;
 };

--- a/src/project/ProjectFolder.h
+++ b/src/project/ProjectFolder.h
@@ -8,7 +8,6 @@
 #include <ObjectList.h>
 #include <String.h>
 
-#include "GenioNamespace.h"
 #include "GSettings.h"
 
 class LSPProjectWrapper;
@@ -30,16 +29,16 @@ class SourceItem {
 public:
 								SourceItem(BString const& path);
 								~SourceItem();
-								
+
 	BString	const				Path() { return fPath; }
 	BString	const				Name() { return fName; };
 	SourceItemType				Type() { return fType; };
-	
+
 	ProjectFolder				*GetProjectFolder()	{ return fProjectFolder; }
 	void						SetProjectFolder(ProjectFolder *projectFolder)	{ fProjectFolder = projectFolder; }
-	
+
 	void 						Rename(BString const& path);
-						
+
 protected:
 	BString						fPath;
 	BString						fName;
@@ -51,40 +50,40 @@ class ProjectFolder : public SourceItem {
 public:
 								ProjectFolder(BString const& path);
 								~ProjectFolder();
-	
+
 	status_t					Open();
 	status_t					Close();
-	
+
 	void						LoadDefaultSettings();
 	void						SaveSettings();
 
 	bool						Active() const { return fActive; }
-	void						Active(bool status) { fActive = status; }	
-	
+	void						Active(bool status) { fActive = status; }
+
 	void						SetBuildMode(BuildMode mode);
 	BuildMode					GetBuildMode();
-	
+
 	void						SetCleanCommand(BString const& command, BuildMode mode);
 	BString const				GetCleanCommand();
-	
+
 	void						SetBuildCommand(BString const& command, BuildMode mode);
 	BString const				GetBuildCommand();
 
 	void						SetExecuteArgs(BString const& args, BuildMode mode);
 	BString const				GetExecuteArgs();
-	
+
 	void						SetTarget(BString const& path, BuildMode mode);
 	BString const				GetTarget();
-	
+
 	void						RunInTerminal(bool enabled);
 	bool						RunInTerminal();
-	
+
 	void						Git(bool enabled);
 	bool						Git();
-	
+
 	void						ExcludeSettingsOnGit(bool enabled);
 	bool						ExcludeSettingsOnGit();
-	
+
 	LSPProjectWrapper*			GetLSPClient() { return fLSPProjectWrapper; }
 
 private:

--- a/src/project/ProjectItem.cpp
+++ b/src/project/ProjectItem.cpp
@@ -70,6 +70,7 @@ ProjectItem::ProjectItem(SourceItem *sourceItem)
 	fSourceItem(sourceItem),
 	fFirstTimeRendered(true),
 	fNeedsSave(false),
+	fOpenedInEditor(false),
 	fInitRename(false),
 	fMessage(nullptr),
 	fTextControl(nullptr)
@@ -134,7 +135,7 @@ ProjectItem::DrawItem(BView* owner, BRect bounds, bool complete)
 		textRect.right = bounds.right;
 		_DrawTextWidget(owner, textRect);
 	} else {
-		if (fNeedsSave) {
+		if (fOpenedInEditor) {
 			BFont font;
 			owner->GetFont(&font);
 			font.SetFace(B_ITALIC_FACE);
@@ -144,7 +145,10 @@ ProjectItem::DrawItem(BView* owner, BRect bounds, bool complete)
 		owner->SetDrawingMode(B_OP_COPY);
 		owner->MovePenTo(iconStartingPoint.x + iconSize + be_control_look->DefaultLabelSpacing(),
 							bounds.top + BaselineOffset());
-		owner->DrawString(Text());
+		BString text = Text();
+		if (fNeedsSave)
+			text.Append("*");
+		owner->DrawString(text.String());
 		owner->Sync();
 
 		if (fFirstTimeRendered) {
@@ -159,6 +163,13 @@ void
 ProjectItem::SetNeedsSave(bool needs)
 {
 	fNeedsSave = needs;
+}
+
+
+void
+ProjectItem::SetOpenedInEditor(bool open)
+{
+	fOpenedInEditor = open;
 }
 
 

--- a/src/project/ProjectItem.cpp
+++ b/src/project/ProjectItem.cpp
@@ -117,10 +117,8 @@ ProjectItem::DrawItem(BView* owner, BRect bounds, bool complete)
 		owner->SetHighColor(ui_color(B_LIST_ITEM_TEXT_COLOR));
 
 	auto icon = IconCache::GetIcon(GetSourceItem()->Path());
-
 	float iconSize = be_control_look->ComposeIconSize(B_MINI_ICON).Height();
 	BPoint iconStartingPoint(bounds.left + 4.0f, bounds.top  + (bounds.Height() - iconSize) / 2.0f);
-
 	if (icon != nullptr) {
 		owner->SetDrawingMode(B_OP_ALPHA);
 		owner->DrawBitmapAsync(icon, iconStartingPoint);
@@ -135,20 +133,10 @@ ProjectItem::DrawItem(BView* owner, BRect bounds, bool complete)
 		textRect.right = bounds.right;
 		_DrawTextWidget(owner, textRect);
 	} else {
-		if (fOpenedInEditor) {
-			BFont font;
-			owner->GetFont(&font);
-			font.SetFace(B_ITALIC_FACE);
-			owner->SetFont(&font);
-		}
-		// Draw string at the right of the icon
-		owner->SetDrawingMode(B_OP_COPY);
-		owner->MovePenTo(iconStartingPoint.x + iconSize + be_control_look->DefaultLabelSpacing(),
-							bounds.top + BaselineOffset());
-		BString text = Text();
-		if (fNeedsSave)
-			text.Append("*");
-		owner->DrawString(text.String());
+		BPoint textPoint(iconStartingPoint.x + iconSize + be_control_look->DefaultLabelSpacing(),
+						bounds.top + BaselineOffset());
+		_DrawText(owner, textPoint);
+
 		owner->Sync();
 
 		if (fFirstTimeRendered) {
@@ -189,6 +177,7 @@ ProjectItem::InitRename(BMessage* message)
 	fMessage = message;
 }
 
+
 void
 ProjectItem::AbortRename()
 {
@@ -196,6 +185,7 @@ ProjectItem::AbortRename()
 		_DestroyTextWidget();
 	fInitRename = false;
 }
+
 
 void
 ProjectItem::CommitRename()
@@ -207,6 +197,26 @@ ProjectItem::CommitRename()
 		_DestroyTextWidget();
 	}
 	fInitRename = false;
+}
+
+
+void
+ProjectItem::_DrawText(BView* owner, const BPoint& point)
+{
+	if (fOpenedInEditor) {
+		BFont font;
+		owner->GetFont(&font);
+		font.SetFace(B_ITALIC_FACE);
+		owner->SetFont(&font);
+	}
+	// Draw string at the right of the icon
+	owner->SetDrawingMode(B_OP_COPY);
+	owner->MovePenTo(point);
+	BString text = Text();
+	if (fNeedsSave)
+		text.Append("*");
+	owner->DrawString(text.String());
+	owner->Sync();
 }
 
 

--- a/src/project/ProjectItem.cpp
+++ b/src/project/ProjectItem.cpp
@@ -20,10 +20,10 @@
 
 class ProjectItem;
 
-class TemporaryTextControl: public BTextControl {	
+class TemporaryTextControl: public BTextControl {
 	typedef	BTextControl _inherited;
-	
-	
+
+
 public:
 	ProjectItem *fProjectItem;
 
@@ -34,14 +34,14 @@ public:
 		BTextControl(frame, name, label, text, message, resizingMode, flags),
 		fProjectItem(item)
 	{
-		SetEventMask(B_POINTER_EVENTS|B_KEYBOARD_EVENTS);	
+		SetEventMask(B_POINTER_EVENTS|B_KEYBOARD_EVENTS);
 	}
-	
+
 	virtual void AllAttached()
 	{
 		TextView()->SelectAll();
 	}
-	
+
 	virtual void MouseDown(BPoint point)
 	{
 		if (Bounds().Contains(point))
@@ -51,7 +51,7 @@ public:
 		}
 		Invoke();
 	}
-	
+
 	virtual void KeyDown(const char* bytes, int32 numBytes)
 	{
 		if (numBytes == 1 && *bytes == B_ESCAPE) {
@@ -69,6 +69,7 @@ ProjectItem::ProjectItem(SourceItem *sourceItem)
 	BStringItem(sourceItem->Name()),
 	fSourceItem(sourceItem),
 	fFirstTimeRendered(true),
+	fNeedsSave(false),
 	fInitRename(false),
 	fMessage(nullptr),
 	fTextControl(nullptr)
@@ -133,6 +134,12 @@ ProjectItem::DrawItem(BView* owner, BRect bounds, bool complete)
 	if (fInitRename) {
 		_DrawTextWidget(owner);
 	} else {
+		if (fNeedsSave) {
+			BFont font;
+			owner->GetFont(&font);
+			font.SetFace(B_ITALIC_FACE);
+			owner->SetFont(&font);
+		}
 		// Draw string at the right of the icon
 		owner->SetDrawingMode(B_OP_COPY);
 		owner->MovePenTo(iconStartingPoint.x + iconSize + be_control_look->DefaultLabelSpacing(),
@@ -145,6 +152,13 @@ ProjectItem::DrawItem(BView* owner, BRect bounds, bool complete)
 			fFirstTimeRendered = false;
 		}
 	}
+}
+
+
+void
+ProjectItem::SetNeedsSave(bool needs)
+{
+	fNeedsSave = needs;
 }
 
 

--- a/src/project/ProjectItem.cpp
+++ b/src/project/ProjectItem.cpp
@@ -120,11 +120,6 @@ ProjectItem::DrawItem(BView* owner, BRect bounds, bool complete)
 	float iconSize = be_control_look->ComposeIconSize(B_MINI_ICON).Height();
 	BPoint iconStartingPoint(bounds.left + 4.0f, bounds.top  + (bounds.Height() - iconSize) / 2.0f);
 
-	fTextRect.top = bounds.top - 0.5f;
-	fTextRect.left = iconStartingPoint.x + iconSize + be_control_look->DefaultLabelSpacing();
-	fTextRect.bottom = bounds.bottom-1;
-	fTextRect.right = bounds.right;
-
 	if (icon != nullptr) {
 		owner->SetDrawingMode(B_OP_ALPHA);
 		owner->DrawBitmapAsync(icon, iconStartingPoint);
@@ -132,7 +127,12 @@ ProjectItem::DrawItem(BView* owner, BRect bounds, bool complete)
 
 	// Check if there is an InitRename request and show a TextControl
 	if (fInitRename) {
-		_DrawTextWidget(owner);
+		BRect textRect;
+		textRect.top = bounds.top - 0.5f;
+		textRect.left = iconStartingPoint.x + iconSize + be_control_look->DefaultLabelSpacing();
+		textRect.bottom = bounds.bottom - 1;
+		textRect.right = bounds.right;
+		_DrawTextWidget(owner, textRect);
 	} else {
 		if (fNeedsSave) {
 			BFont font;
@@ -200,10 +200,10 @@ ProjectItem::CommitRename()
 
 
 void
-ProjectItem::_DrawTextWidget(BView* owner)
+ProjectItem::_DrawTextWidget(BView* owner, const BRect& textRect)
 {
 	if (fTextControl == nullptr) {
-		fTextControl = new TemporaryTextControl(fTextRect, "RenameTextWidget",
+		fTextControl = new TemporaryTextControl(textRect, "RenameTextWidget",
 											"", Text(), fMessage, this,
 											B_FOLLOW_NONE);
 		owner->AddChild(fTextControl);

--- a/src/project/ProjectItem.cpp
+++ b/src/project/ProjectItem.cpp
@@ -15,7 +15,6 @@
 
 #include "IconCache.h"
 #include "ProjectFolder.h"
-#include "Utils.h"
 
 
 class ProjectItem;

--- a/src/project/ProjectItem.h
+++ b/src/project/ProjectItem.h
@@ -19,25 +19,28 @@ class ProjectItem : public BStringItem {
 public:
 					ProjectItem(SourceItem *sourceFile);
 					~ProjectItem();
-						
+
 	void 			DrawItem(BView* owner, BRect bounds, bool complete);
 	void 			Update(BView* owner, const BFont* font);
 	BRect 			GetTextRect() { return fTextRect; }
 
 	SourceItem		*GetSourceItem() const { return fSourceItem; };
-	
+
+	void			SetNeedsSave(bool needs);
+
 	void			InitRename(BMessage* message);
 	void			AbortRename();
 	void			CommitRename();
-	
+
 private:
 	SourceItem		*fSourceItem;
 	bool			fFirstTimeRendered;
+	bool			fNeedsSave;
 	BRect			fTextRect;
 	bool			fInitRename;
 	BMessage*		fMessage;
 	BTextControl	*fTextControl;
-	
+
 	void			_DrawIcon(BView* owner);
 	void			_DrawTextWidget(BView* owner);
 	void			_DestroyTextWidget();

--- a/src/project/ProjectItem.h
+++ b/src/project/ProjectItem.h
@@ -22,7 +22,6 @@ public:
 
 	void 			DrawItem(BView* owner, BRect bounds, bool complete);
 	void 			Update(BView* owner, const BFont* font);
-	BRect 			GetTextRect() { return fTextRect; }
 
 	SourceItem		*GetSourceItem() const { return fSourceItem; };
 
@@ -36,13 +35,12 @@ private:
 	SourceItem		*fSourceItem;
 	bool			fFirstTimeRendered;
 	bool			fNeedsSave;
-	BRect			fTextRect;
 	bool			fInitRename;
 	BMessage*		fMessage;
 	BTextControl	*fTextControl;
 
 	void			_DrawIcon(BView* owner);
-	void			_DrawTextWidget(BView* owner);
+	void			_DrawTextWidget(BView* owner, const BRect& textRect);
 	void			_DestroyTextWidget();
 };
 

--- a/src/project/ProjectItem.h
+++ b/src/project/ProjectItem.h
@@ -26,6 +26,7 @@ public:
 	SourceItem		*GetSourceItem() const { return fSourceItem; };
 
 	void			SetNeedsSave(bool needs);
+	void			SetOpenedInEditor(bool open);
 
 	void			InitRename(BMessage* message);
 	void			AbortRename();
@@ -35,6 +36,7 @@ private:
 	SourceItem		*fSourceItem;
 	bool			fFirstTimeRendered;
 	bool			fNeedsSave;
+	bool			fOpenedInEditor;
 	bool			fInitRename;
 	BMessage*		fMessage;
 	BTextControl	*fTextControl;

--- a/src/project/ProjectItem.h
+++ b/src/project/ProjectItem.h
@@ -41,7 +41,7 @@ private:
 	BMessage*		fMessage;
 	BTextControl	*fTextControl;
 
-	void			_DrawIcon(BView* owner);
+	void			_DrawText(BView* owner, const BPoint& textPoint);
 	void			_DrawTextWidget(BView* owner, const BRect& textRect);
 	void			_DestroyTextWidget();
 };

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -1429,6 +1429,14 @@ GenioWindow::_RemoveTab(int32 index)
 	}
 	Editor* editor = fTabManager->EditorAt(index);
 	fTabManager->RemoveTab(index);
+
+	// notify listeners: file could have been modified, but user
+	// chose not to save
+	BMessage noticeMessage(MSG_NOTIFY_FILE_SAVE_STATUS_CHANGED);
+	noticeMessage.AddString("file_name", editor->FilePath());
+	noticeMessage.AddBool("needs_save", false);
+	SendNotices(MSG_NOTIFY_FILE_SAVE_STATUS_CHANGED, &noticeMessage);
+
 	delete editor;
 
 	// Was it the last one?

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -322,8 +322,10 @@ GenioWindow::MessageReceived(BMessage* message)
 				cmdType == "catkeys") {
 
 				fIsBuilding = false;
-				fProjectsFolderBrowser->SetBuildingPhase(fIsBuilding);
 
+				BMessage noticeMessage(MSG_NOTIFY_BUILDING_PHASE);
+				noticeMessage.AddBool("building", fIsBuilding);
+				SendNotices(MSG_NOTIFY_BUILDING_PHASE, &noticeMessage);
 			}
 			_UpdateProjectActivation(fActiveProject != nullptr);
 			break;
@@ -1339,7 +1341,11 @@ GenioWindow::_BuildProject()
 		_FileSaveAll(fActiveProject);
 
 	fIsBuilding = true;
-	fProjectsFolderBrowser->SetBuildingPhase(fIsBuilding);
+
+	BMessage noticeMessage(MSG_NOTIFY_BUILDING_PHASE);
+	noticeMessage.AddBool("building", fIsBuilding);
+	SendNotices(MSG_NOTIFY_BUILDING_PHASE, &noticeMessage);
+
 	_UpdateProjectActivation(false);
 
 	fBuildLogView->Clear();
@@ -1385,7 +1391,10 @@ GenioWindow::_CleanProject()
 	LogInfoF("Clean started: [%s]", fActiveProject->Name().String());
 
 	fIsBuilding = true;
-	fProjectsFolderBrowser->SetBuildingPhase(fIsBuilding);
+
+	BMessage noticeMessage(MSG_NOTIFY_BUILDING_PHASE);
+	noticeMessage.AddBool("building", fIsBuilding);
+	SendNotices(MSG_NOTIFY_BUILDING_PHASE, &noticeMessage);
 
 	BMessage message;
 	message.AddString("cmd", command);

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -3680,10 +3680,10 @@ GenioWindow::_UpdateSavepointChange(int32 index, const BString& caller)
 	ActionManager::SetEnabled(MSG_FILE_SAVE_ALL, filesNeedSave);
 
 	// Notify all listeners
-	BMessage noticeMessage('abcd');
+	BMessage noticeMessage(MSG_NOTIFY_FILE_SAVE_STATUS_CHANGED);
 	noticeMessage.AddString("file_name", editor->FilePath());
 	noticeMessage.AddBool("needs_save", editor->IsModified());
-	SendNotices('abcd', &noticeMessage);
+	SendNotices(MSG_NOTIFY_FILE_SAVE_STATUS_CHANGED, &noticeMessage);
 
 }
 

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -926,12 +926,12 @@ GenioWindow::MessageReceived(BMessage* message)
 		case MSG_PROJECT_OPEN_REMOTE: {
 			// TODO: There is an attempt ongoing to refactor the whole way we manage the settings
 			// refactor and optimize the settings part
-			// 
+			//
 			TPreferences prefs(GenioNames::kSettingsFileName, GenioNames::kApplicationName, 'PRSE');
 			BEntry entry(prefs.GetString("projects_directory"), true);
 			BPath path;
 			entry.GetPath(&path);
-			
+
 			RemoteProjectWindow *window = new RemoteProjectWindow("", path.Path(), BMessenger(this));
 			window->Show();
 			break;
@@ -2482,7 +2482,7 @@ GenioWindow::_InitActions()
 	ActionManager::RegisterAction(MSG_PROJECT_OPEN,
 								   B_TRANSLATE("Open project"),
 								   "","",'O', B_OPTION_KEY);
-								   
+
 	ActionManager::RegisterAction(MSG_PROJECT_OPEN_REMOTE,
 								   B_TRANSLATE("Open remote project"),
 								   "","",'O', B_SHIFT_KEY | B_OPTION_KEY);
@@ -3678,6 +3678,13 @@ GenioWindow::_UpdateSavepointChange(int32 index, const BString& caller)
 	// or reload editor pointer
 	bool filesNeedSave = (_FilesNeedSave() > 0 ? true : false);
 	ActionManager::SetEnabled(MSG_FILE_SAVE_ALL, filesNeedSave);
+
+	// Notify all listeners
+	BMessage noticeMessage('abcd');
+	noticeMessage.AddString("file_name", editor->FilePath());
+	noticeMessage.AddBool("needs_save", editor->IsModified());
+	SendNotices('abcd', &noticeMessage);
+
 }
 
 // Updating menu, toolbar, title.

--- a/src/ui/GenioWindowMessages.h
+++ b/src/ui/GenioWindowMessages.h
@@ -116,8 +116,9 @@ enum {
 
 // "notification" messages
 enum {
-	MSG_NOTIFY_FILE_SAVE_STATUS_CHANGED = 'stch'	// file_name (string)
+	MSG_NOTIFY_FILE_SAVE_STATUS_CHANGED = 'stch',	// file_name (string)
 													// needs_save (bool)
+	MSG_NOTIFY_BUILDING_PHASE			= 'blph'	// building (bool)
 };
 
 #endif // GenioWindowMessages_H

--- a/src/ui/GenioWindowMessages.h
+++ b/src/ui/GenioWindowMessages.h
@@ -116,7 +116,8 @@ enum {
 
 // "notification" messages
 enum {
-	MSG_NOTIFY_FILE_SAVE_STATUS_CHANGED = 'stch'
+	MSG_NOTIFY_FILE_SAVE_STATUS_CHANGED = 'stch'	// file_name (string)
+													// needs_save (bool)
 };
 
 #endif // GenioWindowMessages_H

--- a/src/ui/GenioWindowMessages.h
+++ b/src/ui/GenioWindowMessages.h
@@ -116,8 +116,11 @@ enum {
 
 // "notification" messages
 enum {
+	MSG_NOTIFY_EDITOR_FILE_OPENED = 	  'efop',	// file_name (string)
+	MSG_NOTIFY_EDITOR_FILE_CLOSED = 	  'efcx',	// file_name (string)
 	MSG_NOTIFY_FILE_SAVE_STATUS_CHANGED = 'stch',	// file_name (string)
 													// needs_save (bool)
+
 	MSG_NOTIFY_BUILDING_PHASE			= 'blph'	// building (bool)
 };
 

--- a/src/ui/GenioWindowMessages.h
+++ b/src/ui/GenioWindowMessages.h
@@ -41,7 +41,7 @@ enum {
 	MSG_EOL_CONVERT_TO_MAC		= 'ectm',
 	MSG_FILE_TRIM_TRAILING_SPACE = 'trim',
 
-  MSG_AUTOCOMPLETION			= 'auto',	
+  MSG_AUTOCOMPLETION			= 'auto',
 	MSG_FORMAT					= 'form',
 	MSG_GOTODEFINITION			= 'gode',
 	MSG_GOTODECLARATION			= 'gocl',
@@ -71,7 +71,7 @@ enum {
 	MSG_BOOKMARK_GOTO_NEXT		= 'bgne',
 	MSG_BOOKMARK_GOTO_PREVIOUS	= 'bgpr',
 	MSG_BOOKMARK_TOGGLE			= 'book',
-	
+
 	// Build menu
 	MSG_BUILD_PROJECT			= 'bupr',
 	MSG_BUILD_PROJECT_STOP		= 'bpst',
@@ -91,7 +91,7 @@ enum {
 	MSG_WINDOW_SETTINGS			= 'wise',
 	MSG_TOGGLE_TOOLBAR			= 'toto',
 
-	
+
 	// Toolbar
 	MSG_BUFFER_LOCK					= 'bulo',
 	MSG_FILE_MENU_SHOW				= 'fmsh',
@@ -106,11 +106,17 @@ enum {
 	MSG_SHOW_HIDE_PROJECTS			= 'shpr',
 	MSG_SHOW_HIDE_OUTPUT			= 'shou',
 	MSG_SELECT_TAB					= 'seta',
-		
+
 	MSG_ESCAPE_KEY					= 'escp',
-	
+
 	MSG_SHOW_TEMPLATE_USER_FOLDER	= 'stuf',
 	MSG_CREATE_NEW_PROJECT			= 'mcnp'
+};
+
+
+// "notification" messages
+enum {
+	MSG_NOTIFY_FILE_SAVE_STATUS_CHANGED = 'stch'
 };
 
 #endif // GenioWindowMessages_H

--- a/src/ui/ProjectsFolderBrowser.cpp
+++ b/src/ui/ProjectsFolderBrowser.cpp
@@ -342,8 +342,10 @@ ProjectsFolderBrowser::MessageReceived(BMessage* message)
 					message->FindBool("needs_save", &needsSave);
 					message->FindString("file_name", &fileName);
 					ProjectItem* item = FindProjectItem(fileName);
-					if (item != nullptr)
+					if (item != nullptr) {
 						item->SetNeedsSave(needsSave);
+						Invalidate();
+					}
 					break;
 				}
 				default:

--- a/src/ui/ProjectsFolderBrowser.cpp
+++ b/src/ui/ProjectsFolderBrowser.cpp
@@ -621,13 +621,8 @@ ProjectsFolderBrowser::ProjectFolderPopulate(ProjectFolder* project)
 void
 ProjectsFolderBrowser::_ProjectFolderScan(ProjectItem* item, BString const& path, ProjectFolder *projectFolder)
 {
-	char name[B_FILE_NAME_LENGTH];
-	BEntry nextEntry;
-	BEntry entry(path);
-	entry.GetName(name);
-
 	ProjectItem *newItem;
-	if (item != NULL) {
+	if (item != nullptr) {
 		SourceItem *sourceItem = new SourceItem(path);
 		sourceItem->SetProjectFolder(projectFolder);
 		newItem = new ProjectItem(sourceItem);
@@ -638,6 +633,7 @@ ProjectsFolderBrowser::_ProjectFolderScan(ProjectItem* item, BString const& path
 		AddItem(newItem);
 	}
 
+	BEntry entry(path);
 	BEntry parent;
 	BPath parentPath;
 	// Check if there's a Jamfile or makefile in the root path
@@ -645,7 +641,6 @@ ProjectsFolderBrowser::_ProjectFolderScan(ProjectItem* item, BString const& path
 	if (entry.IsFile() && entry.GetParent(&parent) == B_OK
 		&& parent.GetPath(&parentPath) == B_OK
 		&& projectFolder->Path().Compare(parentPath.Path()) == 0) {
-		LogInfo("Guessing builder...");
 		// guess builder type
 		// TODO: do it for real: set a flag or setting in project
 		// TODO: move this away from here, into a specialized class
@@ -660,6 +655,7 @@ ProjectsFolderBrowser::_ProjectFolderScan(ProjectItem* item, BString const& path
 	} else if (entry.IsDirectory()) {
 		BPath _currentPath;
 		BDirectory dir(&entry);
+		BEntry nextEntry;
 		while (dir.GetNextEntry(&nextEntry, false) != B_ENTRY_NOT_FOUND) {
 			nextEntry.GetPath(&_currentPath);
 			_ProjectFolderScan(newItem, _currentPath.Path(), projectFolder);

--- a/src/ui/ProjectsFolderBrowser.cpp
+++ b/src/ui/ProjectsFolderBrowser.cpp
@@ -277,6 +277,7 @@ ProjectsFolderBrowser::_UpdateNode(BMessage* message)
 }
 
 
+/* virtual */
 void
 ProjectsFolderBrowser::MessageReceived(BMessage* message)
 {
@@ -465,6 +466,7 @@ ProjectsFolderBrowser::GetProjectFromCurrentItem()
 	return _GetProjectFromItem(GetCurrentProjectItem());
 }
 
+
 BString const
 ProjectsFolderBrowser::GetCurrentProjectFileFullPath()
 {
@@ -492,6 +494,7 @@ ProjectsFolderBrowser::_GetProjectFromItem(ProjectItem* item)
 	return project;
 }
 
+
 status_t
 ProjectsFolderBrowser::_RenameCurrentSelectedFile(const BString& new_name)
 {
@@ -506,6 +509,7 @@ ProjectsFolderBrowser::_RenameCurrentSelectedFile(const BString& new_name)
 }
 
 
+/* virtual */
 void
 ProjectsFolderBrowser::AttachedToWindow()
 {
@@ -518,7 +522,18 @@ ProjectsFolderBrowser::AttachedToWindow()
 	}
 }
 
+/* virtual */
+void
+ProjectsFolderBrowser::DetachedFromWindow()
+{
+	if (Window()->LockLooper()) {
+		Window()->StopWatching(this, MSG_NOTIFY_FILE_SAVE_STATUS_CHANGED);
+		Window()->UnlockLooper();
+	}
+}
 
+
+/* virtual */
 void
 ProjectsFolderBrowser::MouseDown(BPoint where)
 {

--- a/src/ui/ProjectsFolderBrowser.cpp
+++ b/src/ui/ProjectsFolderBrowser.cpp
@@ -513,7 +513,7 @@ ProjectsFolderBrowser::AttachedToWindow()
 	BOutlineListView::SetTarget((BHandler*)this, Window());
 
 	if (Window()->LockLooper()) {
-		Window()->StartWatching(this, 'abcd');
+		Window()->StartWatching(this, MSG_NOTIFY_FILE_SAVE_STATUS_CHANGED);
 		Window()->UnlockLooper();
 	}
 }

--- a/src/ui/ProjectsFolderBrowser.cpp
+++ b/src/ui/ProjectsFolderBrowser.cpp
@@ -367,7 +367,7 @@ ProjectsFolderBrowser::MessageReceived(BMessage* message)
 				{
 					bool building = false;
 					message->FindBool("building", &building);
-					SetBuildingPhase(building);
+					fIsBuilding = building;
 					break;
 				}
 

--- a/src/ui/ProjectsFolderBrowser.cpp
+++ b/src/ui/ProjectsFolderBrowser.cpp
@@ -335,7 +335,7 @@ ProjectsFolderBrowser::MessageReceived(BMessage* message)
 			int32 code;
 			message->FindInt32(B_OBSERVE_WHAT_CHANGE, &code);
 			switch (code) {
-				case 'abcd':
+				case MSG_NOTIFY_FILE_SAVE_STATUS_CHANGED:
 				{
 					bool needsSave = false;
 					BString fileName;

--- a/src/ui/ProjectsFolderBrowser.cpp
+++ b/src/ui/ProjectsFolderBrowser.cpp
@@ -647,9 +647,11 @@ ProjectsFolderBrowser::_ProjectFolderScan(ProjectItem* item, BString const& path
 		// and maybe into plugins
 		if (strcasecmp(entry.Name(), "makefile") == 0) {
 			// builder: make
+			projectFolder->SetGuessedBuilder("make");
 			LogInfo("Guessed builder: make");
 		} else if (strcasecmp(entry.Name(), "jamfile") == 0) {
 			// builder: jam
+			projectFolder->SetGuessedBuilder("jam");
 			LogInfo("Guessed builder: jam");
 		}
 	} else if (entry.IsDirectory()) {

--- a/src/ui/ProjectsFolderBrowser.h
+++ b/src/ui/ProjectsFolderBrowser.h
@@ -44,8 +44,6 @@ public:
 
 	BString const	GetCurrentProjectFileFullPath();
 
-	void			SetBuildingPhase(bool building) { fIsBuilding = building;};
-
 	void			ProjectFolderPopulate(ProjectFolder* project);
 	void			ProjectFolderDepopulate(ProjectFolder* project);
 

--- a/src/ui/ProjectsFolderBrowser.h
+++ b/src/ui/ProjectsFolderBrowser.h
@@ -32,51 +32,52 @@ class ProjectsFolderBrowser : public BOutlineListView {
 public:
 					 ProjectsFolderBrowser();
 	virtual 		~ProjectsFolderBrowser();
-	
-	void			MouseDown(BPoint where);
-	void			AttachedToWindow();
-	void			MessageReceived(BMessage* message);
-	
+
+	virtual void	MouseDown(BPoint where);
+	virtual void	AttachedToWindow();
+	virtual void	DetachedFromWindow();
+	virtual void	MessageReceived(BMessage* message);
+
 	ProjectFolder*	GetProjectFromCurrentItem();
-	
+
 	ProjectItem*	GetCurrentProjectItem();
-	
+
 	BString const	GetCurrentProjectFileFullPath();
-	
+
 	void			SetBuildingPhase(bool building) { fIsBuilding = building;};
-	
+
 	void			ProjectFolderPopulate(ProjectFolder* project);
 	void			ProjectFolderDepopulate(ProjectFolder* project);
-	
+
 	virtual void	SelectionChanged();
-	
+
 	void			InitRename(ProjectItem *item);
-	
+
 private:
-	
+
 	ProjectItem*	FindProjectItem(BString const& path);
-	
+
 	ProjectItem*	_CreatePath(BPath pathToCreate);
-	
+
 	void			_ProjectFolderScan(ProjectItem* item, BString const& path, ProjectFolder *projectFolder = NULL);
 
 	void			_ShowProjectItemPopupMenu(BPoint where);
 	ProjectFolder*	_GetProjectFromItem(ProjectItem*);
-	
+
 	static	int		_CompareProjectItems(const BListItem* a, const BListItem* b);
-	
+
 	void			_UpdateNode(BMessage *message);
-	
+
 	status_t		_RenameCurrentSelectedFile(const BString& newName);
 
 	ProjectItem*	_CreateNewProjectItem(ProjectItem* parentItem, BPath path);
-	
+
 private:
 	TemplatesMenu*		fFileNewProjectMenuItem;
-	
+
 	bool				fIsBuilding = false;
 	GenioWatchingFilter* fGenioWatchingFilter;
-	
+
 };
 
 


### PR DESCRIPTION
Now items in the project browser reflects the status of the editor:

Opened files are rendered in italic.
Unsaved files get a trailing asterisk on their names.
Implements #19 

Also try to guess the project builder type, so in most cases, there is no need to manually configure project settings (#27)

Cleanups.
