### PR TITLE
Sentence casing and consistency

### DIFF
--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.Genio	3929594733
+1	English	application/x-vnd.Genio	1597770580
 Close	RemoteProjectWindow		Close
 Copy	GenioWindow		Copy
 Create new branch from \"%selected_branch%\"	SourceControlPanel		Create new branch from \"%selected_branch%\"
@@ -8,8 +8,8 @@ Clear	ConsoleIOView		Clear
 Project	EditorTabManager		Project
 Open remote project	GenioWindow		Open remote project
 Switch source/header	GenioWindow		Switch source/header
-Project	ProjectsFolderBrowser		Project
 Comment selected lines	GenioWindow		Comment selected lines
+Project	ProjectsFolderBrowser		Project
 Make file read-only	GenioWindow		Make file read-only
 Stashed changes popped.	SourceControlPanel		Stashed changes popped.
 Show toolbar	GenioWindow		Show toolbar
@@ -26,6 +26,8 @@ Open file	ProjectsFolderBrowser		Open file
 Problems	ProblemsPanel		Problems
 Window	GenioWindow		Window
 Line endings	GenioWindow		Line endings
+Tab width:	SettingsWindow		Tab width:
+Edge column:	SettingsWindow		Edge column:
 Open files list	GenioWindow		Open files list
 Cancel	SourceControlPanel		Cancel
 Projects folder:	SettingsWindow		Projects folder:
@@ -33,7 +35,6 @@ Set active	ProjectsFolderBrowser		Set active
 Fetch prune	SourceControlPanel		Fetch prune
 Editor zoom:	SettingsWindow		Editor zoom:
 Genio is a fork of Ideam and available under the MIT license.	GenioApp		Genio is a fork of Ideam and available under the MIT license.
-This setting will be updated on restart	SettingsWindow		This setting will be updated on restart
 Run in Terminal	ProjectSettingsWindow		Run in Terminal
 Wrap	GenioWindow		Wrap
 Save all	GenioWindow		Save all
@@ -51,8 +52,8 @@ Ok	GitAlert		Ok
 Build log	GenioWindow		Build log
 Continue	RemoteProjectWindow		Continue
 Close file	GenioWindow		Close file
-Switch to \"%selected_branch%\"	SourceControlPanel		Switch to \"%selected_branch%\"
 Editor style:	SettingsWindow		Editor style:
+Switch to \"%selected_branch%\"	SourceControlPanel		Switch to \"%selected_branch%\"
 Find previous	GenioWindow		Find previous
 Show projects pane	SettingsWindow		Show projects pane
 Redo	GenioWindow		Redo
@@ -146,7 +147,6 @@ Match case	GenioWindow		Match case
 There are unsaved changes.\nSelect the files to save.	QuitAlert		There are unsaved changes.\nSelect the files to save.
 Pull (rebase)	GenioWindow	The git command	Pull (rebase)
 Pull	GenioWindow	The git command	Pull
-Edge column	SettingsWindow		Edge column
 Save	GenioWindow		Save
 Restarting build…	ConsoleIOView		Restarting build…
 The project folder has been deleted or moved to another location and it will be closed and unloaded from the workspace.	ProjectsFolderBrowser		The project folder has been deleted or moved to another location and it will be closed and unloaded from the workspace.
@@ -160,6 +160,7 @@ Open	GenioWindow		Open
 stdout	ConsoleIOView		stdout
 Save all files	GenioWindow		Save all files
 Save selected	QuitAlert		Save selected
+Search results	SearchResultPanel		Search results
 Reload projects	SettingsWindow		Reload projects
 Console banner	SettingsWindow		Console banner
 Overwrite	GenioWindow		Overwrite
@@ -197,7 +198,6 @@ See credits for a complete list.\n\n	GenioApp		See credits for a complete list.\
 Reset zoom	GenioWindow		Reset zoom
 Don't save	Editor		Don't save
 Stop	ConsoleIOView		Stop
-Tab width:  	SettingsWindow		Tab width:  
 Show line endings	SettingsWindow		Show line endings
 Show toolbar	SettingsWindow		Show toolbar
 Repository scroll view	SourceControlPanel		Repository scroll view
@@ -228,6 +228,7 @@ The project folder has been renamed. It will be closed and reopened automaticall
 Cut	GenioWindow		Cut
 Font size:	SettingsWindow		Font size:
 Zoom out	GenioWindow		Zoom out
+Exclude folders:	SettingsWindow		Exclude folders:
 Match case	SettingsWindow		Match case
 Base path:	RemoteProjectWindow		Base path:
 Save as…	GenioWindow		Save as…
@@ -247,10 +248,12 @@ Show line endings	GenioWindow		Show line endings
 Could not create a new file	GenioWindow		Could not create a new file
 Save all	QuitAlert		Save all
 Close project	ProjectsFolderBrowser		Close project
+Source control	SourceControlPanel		Source control
 Delete folder	ProjectsFolderBrowser		Delete folder
 Options	SourceControlPanel		Options
 Format	GenioWindow		Format
 Enable syntax highlighting	SettingsWindow		Enable syntax highlighting
+This setting will be updated on restart.	SettingsWindow		This setting will be updated on restart.
 Show in Tracker	ProjectsFolderBrowser		Show in Tracker
 Release build command:	ProjectSettingsWindow		Release build command:
 Defaults	ConfigWindow		Defaults
@@ -293,7 +296,6 @@ Genio uses:\nScintilla lib\nCopyright 1998-2003 by Neil Hodgson <neilh@scintilla
 Clean project	ProjectsFolderBrowser		Clean project
 Debug clean command:	ProjectSettingsWindow		Debug clean command:
 Build project	ProjectsFolderBrowser		Build project
-Search Results	SearchResultPanel		Search Results
 Remotes	SourceControlPanel		Remotes
 Choose project…	SourceControlPanel		Choose project…
 An error occurred while switching branch:	GenioWindow		An error occurred while switching branch:
@@ -316,4 +318,3 @@ Don't save	QuitAlert		Don't save
 An unknown error occurred.	SourceControlPanel		An unknown error occurred.
 Build commands	ProjectSettingsWindow		Build commands
 Save caret position	SettingsWindow		Save caret position
-Source Control	SourceControlPanel		Source Control

--- a/src/GenioApp.cpp
+++ b/src/GenioApp.cpp
@@ -303,13 +303,13 @@ GenioApp::PrepareConfig(ConfigManager& cfg)
 		{"mode", "options"},
 		{"option_1", {
 			{"value", (int32)Logger::LOGGER_DEST_STDOUT },
-			{"label", "Stdout" }}},
+			{"label", "stdout" }}},
 		{"option_2", {
 			{"value", (int32)Logger::LOGGER_DEST_STDERR },
-			{"label", "Stderr"}}},
+			{"label", "stderr"}}},
 		{"option_3", {
 			{"value", (int32)Logger::LOGGER_DEST_SYSLOG },
-			{"label", "Syslog"}}},
+			{"label", "syslog"}}},
 		{"option_4", {
 			{"value", (int32)Logger::LOGGER_DEST_BEDC },
 			{"label", "BeDC"}}}
@@ -392,7 +392,7 @@ GenioApp::PrepareConfig(ConfigManager& cfg)
 
 	cfg.AddConfig("Editor/Visual", "show_edgeline", B_TRANSLATE("Show edge line"), true);
 	GMessage limits = {{ {"min", 0}, {"max", 500} }};
-	cfg.AddConfig("Editor/Visual", "edgeline_column", B_TRANSLATE("Edge column"), 100, &limits);
+	cfg.AddConfig("Editor/Visual", "edgeline_column", B_TRANSLATE("Edge column:"), 100, &limits);
 
 	cfg.AddConfig("Build", "wrap_console",   B_TRANSLATE("Wrap console"), false);
 	cfg.AddConfig("Build", "console_banner", B_TRANSLATE("Console banner"), true);
@@ -403,11 +403,11 @@ GenioApp::PrepareConfig(ConfigManager& cfg)
 	cfg.AddConfig("Editor/Find", "find_wrap", B_TRANSLATE("Wrap"), false);
 	cfg.AddConfig("Editor/Find", "find_whole_word", B_TRANSLATE("Whole word"), false);
 	cfg.AddConfig("Editor/Find", "find_match_case", B_TRANSLATE("Match case"), false);
-	cfg.AddConfig("Editor/Find", "find_exclude_directory", B_TRANSLATE("Exclude Directories"),
+	cfg.AddConfig("Editor/Find", "find_exclude_directory", B_TRANSLATE("Exclude folders:"),
 															".*,objects.*");
 
 	GMessage lsplevels = { {"mode", "options"},
-						   {"note", B_TRANSLATE("This setting will be updated on restart")},
+						   {"note", B_TRANSLATE("This setting will be updated on restart.")},
 						   {"option_1", {
 								{"value", (int32)lsp_log_level::LSP_LOG_LEVEL_ERROR },
 								{"label", "Error" }}},

--- a/src/git/SourceControlPanel.cpp
+++ b/src/git/SourceControlPanel.cpp
@@ -49,7 +49,7 @@ enum MainIndex {
 
 
 SourceControlPanel::SourceControlPanel()
-	: BView(B_TRANSLATE("Source Control"), B_WILL_DRAW | B_FRAME_EVENTS ),
+	: BView(B_TRANSLATE("Source control"), B_WILL_DRAW | B_FRAME_EVENTS ),
 	fProjectMenu(nullptr),
 	fBranchMenu(nullptr),
 	fProjectList(nullptr),

--- a/src/ui/SearchResultPanel.cpp
+++ b/src/ui/SearchResultPanel.cpp
@@ -57,7 +57,7 @@ public:
 	}
 };
 
-#define SearchResultPanelLabel B_TRANSLATE("Search Results")
+#define SearchResultPanelLabel B_TRANSLATE("Search results")
 
 SearchResultPanel::SearchResultPanel(BTabView* tabView): BColumnListView(SearchResultPanelLabel,
 									B_NAVIGABLE, B_FANCY_BORDER, true)


### PR DESCRIPTION
* Sentence casing
* Haiku terminology for "directory" is "folder".
* Add ":" to labels of text controls and menus.
* The "Build log" uses lower case stderr and stdout, which is the usual usage, I think. Do the same in Log destination of the settings. Since the "syslog" file is also named lower-case, do it here as well.
* Updated en.catkeys