### PR TITLE
Minor GUI string corrections

### DIFF
--- a/src/alert/GAlert.h
+++ b/src/alert/GAlert.h
@@ -144,7 +144,7 @@ private:
 	void _InitInterface()
 	{
 		fMessageString = new BStringView("message", fMessage);
-		fOK = new BButton(B_TRANSLATE("Ok"), new BMessage(OkButton));
+		fOK = new BButton(B_TRANSLATE("OK"), new BMessage(OkButton));
 		fCancel = new BButton(B_TRANSLATE("Cancel"), new BMessage(CancelButton));
 		fOK->MakeDefault(true);
 		fMainView = new BBox(B_NO_BORDER, nullptr);

--- a/src/git/GitAlert.cpp
+++ b/src/git/GitAlert.cpp
@@ -55,7 +55,7 @@ void
 GitAlert::_InitInterface()
 {
 	fMessageString = new BStringView("message", fMessage);
-	fOK = new BButton(B_TRANSLATE("Ok"), new BMessage(B_QUIT_REQUESTED));
+	fOK = new BButton(B_TRANSLATE("OK"), new BMessage(B_QUIT_REQUESTED));
 	BGroupView* filesView = new BGroupView(B_VERTICAL, 0);
 	filesView->SetViewUIColor(B_CONTROL_BACKGROUND_COLOR);
 	fScrollView = new BScrollView("files", filesView, 0, false, true);

--- a/src/git/SourceControlPanel.cpp
+++ b/src/git/SourceControlPanel.cpp
@@ -138,7 +138,7 @@ void
 SourceControlPanel::_InitRepositoryView()
 {
 	fRepositoryView = new RepositoryView();
-	fRepositoryViewScroll = new BScrollView(B_TRANSLATE("Repository scroll view"),
+	fRepositoryViewScroll = new BScrollView("Repository scroll view",
 		fRepositoryView, B_FRAME_EVENTS | B_WILL_DRAW, true, true, border_style::B_NO_BORDER);
 }
 
@@ -176,7 +176,7 @@ SourceControlPanel::_InitRepositoryNotInitializedView()
 {
 	auto stringView = new BStringView("InitMessage",
 		B_TRANSLATE("This project does not have a git repository.\n"
-			" Click below to initialize it"));
+			"Click below to initialize it."));
 	fInitializeButton = new BButton(B_TRANSLATE("Init repository"),
 		new BMessage(MsgInitializeRepository));
 	fDoNotCreateInitialCommitCheckBox = new BCheckBox(B_TRANSLATE("Do not create the initial commit"),

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -2702,7 +2702,7 @@ GenioWindow::_InitMenu()
 	BMenu* appMenu = new BMenu("");
 	appMenu->AddItem(new BMenuItem(B_TRANSLATE("About" B_UTF8_ELLIPSIS),
 		new BMessage(B_ABOUT_REQUESTED)));
-	appMenu->AddItem(new BMenuItem(B_TRANSLATE("Github page" B_UTF8_ELLIPSIS),
+	appMenu->AddItem(new BMenuItem(B_TRANSLATE("Genio project" B_UTF8_ELLIPSIS),
 		new BMessage(MSG_HELP_GITHUB)));
 	appMenu->AddSeparatorItem();
 	appMenu->AddItem(new BMenuItem(B_TRANSLATE("Settings" B_UTF8_ELLIPSIS),


### PR DESCRIPTION
* "Ok" -> "OK"

* Internal scroll view name needs no translation

* "Github page" may be mistaken to go to the user's project's page. "Genio project" is more precise and flexible should Genio one day move away from GitHub as hoster.