### PR TITLE
SourceItem: keep an entry_ref instead of a path

### DIFF
--- a/src/project/ProjectFolder.cpp
+++ b/src/project/ProjectFolder.cpp
@@ -17,20 +17,16 @@
 
 SourceItem::SourceItem(BString const& path)
 	:
-	fName(),
 	fType(SourceItemType::FileItem),
 	fProjectFolder(nullptr)
 {
-	BPath _path(path);
-	fName = _path.Leaf();
-
-	status_t status = get_ref_for_path(_path.Path(), &fEntryRef);
+	status_t status = get_ref_for_path(path.String(), &fEntryRef);
 	if (status != B_OK) {
 		// TODO: What to do ?
-		LogError("Failed to get ref for path %s: %s", _path.Path(), ::strerror(status));
+		LogError("Failed to get ref for path %s: %s", path.String(), ::strerror(status));
 	}
 
-	BEntry entry(path);
+	BEntry entry(path.String());
 	if (entry.IsDirectory())
 		fType = SourceItemType::FolderItem;
 	else
@@ -63,12 +59,17 @@ SourceItem::Path() const
 }
 
 
+BString	const
+SourceItem::Name() const
+{
+	return fEntryRef.name;
+}
+
+
 void
 SourceItem::Rename(BString const& path)
 {
-	BPath _path(path);
-	get_ref_for_path(_path.Path(), &fEntryRef);
-	fName = _path.Leaf();
+	get_ref_for_path(path.String(), &fEntryRef);
 }
 
 

--- a/src/project/ProjectFolder.cpp
+++ b/src/project/ProjectFolder.cpp
@@ -67,6 +67,7 @@ void
 SourceItem::Rename(BString const& path)
 {
 	BPath _path(path);
+	get_ref_for_path(_path.Path(), &fEntryRef);
 	fName = _path.Leaf();
 }
 

--- a/src/project/ProjectFolder.h
+++ b/src/project/ProjectFolder.h
@@ -38,7 +38,7 @@ public:
 
 	const entry_ref*			EntryRef() const;
 	BString	const				Path() const;
-	BString	const				Name() const { return fName; };
+	BString	const				Name() const;
 	SourceItemType				Type() const { return fType; };
 
 	ProjectFolder				*GetProjectFolder()	const { return fProjectFolder; }
@@ -47,7 +47,6 @@ public:
 	void 						Rename(BString const& path);
 private:
 	entry_ref					fEntryRef;
-	BString						fName;
 protected:
 	SourceItemType				fType;
 	ProjectFolder				*fProjectFolder;

--- a/src/project/ProjectFolder.h
+++ b/src/project/ProjectFolder.h
@@ -6,7 +6,7 @@
 #define PROJECT_FOLDER_H
 
 
-//#include <Messenger.h>
+#include <Entry.h>
 #include <ObjectList.h>
 #include <String.h>
 
@@ -36,7 +36,8 @@ public:
 								SourceItem(BString const& path);
 								~SourceItem();
 
-	BString	const				Path() const { return fPath; }
+	const entry_ref*			EntryRef() const;
+	BString	const				Path() const;
 	BString	const				Name() const { return fName; };
 	SourceItemType				Type() const { return fType; };
 
@@ -44,10 +45,10 @@ public:
 	void						SetProjectFolder(ProjectFolder *projectFolder)	{ fProjectFolder = projectFolder; }
 
 	void 						Rename(BString const& path);
-
-protected:
-	BString						fPath;
+private:
+	entry_ref					fEntryRef;
 	BString						fName;
+protected:
 	SourceItemType				fType;
 	ProjectFolder				*fProjectFolder;
 };

--- a/src/project/ProjectItem.cpp
+++ b/src/project/ProjectItem.cpp
@@ -236,7 +236,6 @@ void
 ProjectItem::CommitRename()
 {
 	if (fTextControl != nullptr) {
-		SetText(fTextControl->Text());
 		_DestroyTextWidget();
 	}
 }


### PR DESCRIPTION
Fix renaming a folder in ProjectFolderBrowser.

Fixes #212 

Keep an entry_ref in SourceItem instead of a path.
Recalculate Path() and Name() on the fly from the entry_ref.
Also remove changing the item text when renaming, since the rename will be picked up by node monitoring. This also fixes #182 
