### PR TITLE
Fix/colors with box

### DIFF
--- a/src/helpers/tabview/TabManager.cpp
+++ b/src/helpers/tabview/TabManager.cpp
@@ -687,7 +687,10 @@ void WebTabView::_DrawCloseButton(BView* owner, BRect& frame,
 	closeRect.bottom = closeRect.top + 6;
 
 	rgb_color base = ui_color(B_PANEL_BACKGROUND_COLOR);
-	float tint = B_DARKEN_1_TINT;
+	float tint = B_LIGHTEN_1_TINT;
+	if (base.Brightness() > 126)
+		tint = B_DARKEN_1_TINT;
+
 	if (!IsFront()) {
 		base = tint_color(base, tint);
 		tint *= 1.02;

--- a/src/helpers/tabview/TabManager.cpp
+++ b/src/helpers/tabview/TabManager.cpp
@@ -704,8 +704,9 @@ void WebTabView::_DrawCloseButton(BView* owner, BRect& frame,
 
 	rgb_color base = ui_color(B_PANEL_BACKGROUND_COLOR);
 	float tint = B_LIGHTEN_1_TINT;
-	if (base.Brightness() >= 120)
-		tint = B_DARKEN_1_TINT;
+	if (base.Brightness() >= 120) {
+		tint = B_DARKEN_1_TINT *1.2;
+	}
 
 	if (fOverCloseRect) {
 		// Draw the button frame
@@ -716,6 +717,7 @@ void WebTabView::_DrawCloseButton(BView* owner, BRect& frame,
 		rgb_color background = ui_color(B_CONTROL_BACKGROUND_COLOR);
 		be_control_look->DrawButtonBackground(owner, buttonRect, updateRect,
 			background, BControlLook::B_ACTIVATED);
+
 	}
 
 	// Draw the ×

--- a/src/helpers/tabview/TabManager.cpp
+++ b/src/helpers/tabview/TabManager.cpp
@@ -675,6 +675,16 @@ WebTabView::_CloseRectFrame(BRect frame) const
 }
 
 
+static void
+increase_contrast(float& tint, const float& value, const int& brightness)
+{
+	if (brightness >= 120)
+		tint *= value;
+	else
+		tint /= value;
+}
+
+
 void WebTabView::_DrawCloseButton(BView* owner, BRect& frame,
 	const BRect& updateRect, bool isFirst, bool isLast, bool isFront)
 {
@@ -688,18 +698,18 @@ void WebTabView::_DrawCloseButton(BView* owner, BRect& frame,
 
 	rgb_color base = ui_color(B_PANEL_BACKGROUND_COLOR);
 	float tint = B_LIGHTEN_1_TINT;
-	if (base.Brightness() > 126)
+	if (base.Brightness() >= 120)
 		tint = B_DARKEN_1_TINT;
 
 	if (!IsFront()) {
 		base = tint_color(base, tint);
-		tint *= 1.02;
+		increase_contrast(tint, 1.02, base.Brightness());
 	}
 
 	if (fOverCloseRect)
-		tint *= 1.4;
+		increase_contrast(tint, 1.4, base.Brightness());
 	else
-		tint *= 1.2;
+		increase_contrast(tint, 1.2, base.Brightness());
 
 	if (fClicked && fOverCloseRect) {
 		// Draw the button frame
@@ -710,7 +720,7 @@ void WebTabView::_DrawCloseButton(BView* owner, BRect& frame,
 		be_control_look->DrawButtonBackground(owner, buttonRect, updateRect,
 			base, BControlLook::B_ACTIVATED);
 		closeRect.OffsetBy(1, 1);
-		tint *= 1.2;
+		increase_contrast(tint, 1.2, base.Brightness());
 	}
 
 	// Draw the ×

--- a/src/helpers/tabview/TabManager.cpp
+++ b/src/helpers/tabview/TabManager.cpp
@@ -10,6 +10,7 @@
 
 #include "TabManager.h"
 
+#include <Alert.h>
 #include <Application.h>
 #include <AbstractLayoutItem.h>
 #include <Bitmap.h>
@@ -29,6 +30,7 @@
 
 #include "TabContainerView.h"
 #include "TabView.h"
+#include "Utils.h"
 
 
 #undef B_TRANSLATION_CONTEXT
@@ -676,12 +678,9 @@ WebTabView::_CloseRectFrame(BRect frame) const
 
 
 static void
-increase_contrast(float& tint, const float& value, const int& brightness)
+decrease_contrast(float& tint, const float& value, const int& brightness)
 {
-	if (brightness >= 120)
-		tint *= value;
-	else
-		tint /= value;
+	tint = tint * (1 + ((brightness >= 120) ? +1 : -1)*value);
 }
 
 
@@ -701,29 +700,20 @@ void WebTabView::_DrawCloseButton(BView* owner, BRect& frame,
 	if (base.Brightness() >= 120)
 		tint = B_DARKEN_1_TINT;
 
-	if (!IsFront()) {
-		base = tint_color(base, tint);
-		increase_contrast(tint, 1.02, base.Brightness());
-	}
-
-	if (fOverCloseRect)
-		increase_contrast(tint, 1.4, base.Brightness());
-	else
-		increase_contrast(tint, 1.2, base.Brightness());
-
-	if (fClicked && fOverCloseRect) {
+	if (fOverCloseRect) {
 		// Draw the button frame
 		BRect buttonRect(closeRect.InsetByCopy(-4, -4));
 		be_control_look->DrawButtonFrame(owner, buttonRect, updateRect,
 			base, base,
 			BControlLook::B_ACTIVATED | BControlLook::B_BLEND_FRAME);
+		rgb_color background = ui_color(B_CONTROL_BACKGROUND_COLOR);
 		be_control_look->DrawButtonBackground(owner, buttonRect, updateRect,
-			base, BControlLook::B_ACTIVATED);
-		closeRect.OffsetBy(1, 1);
-		increase_contrast(tint, 1.2, base.Brightness());
+			background, BControlLook::B_ACTIVATED);
 	}
 
 	// Draw the ×
+	if (fClicked)
+		decrease_contrast(tint, .2, base.Brightness());
 	base = tint_color(base, tint);
 	owner->SetHighColor(base);
 	owner->SetPenSize(2);

--- a/src/helpers/tabview/TabManager.cpp
+++ b/src/helpers/tabview/TabManager.cpp
@@ -25,13 +25,12 @@
 #include <Rect.h>
 #include <SpaceLayoutItem.h>
 #include <Window.h>
-#include "Log.h"
-#include <iostream>
 
 #include "TabContainerView.h"
 #include "TabView.h"
 #include "Utils.h"
 
+#include <stdexcept>
 
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "Tab Manager"
@@ -678,14 +677,14 @@ WebTabView::_CloseRectFrame(BRect frame) const
 
 
 static void inline
-decreaseContrastBy(float& tint, const float& value, const int& brightness)
+DecreaseContrastBy(float& tint, const float& value, const int& brightness)
 {
 	tint *= 1 + ((brightness >= 120) ? -1 : +1) * value;
 }
 
 
 static void inline
-increaseContrastBy(float& tint, const float& value, const int& brightness)
+IncreaseContrastBy(float& tint, const float& value, const int& brightness)
 {
 	tint *= 1 + ((brightness >= 120) ? +1 : -1) * value;
 }
@@ -722,7 +721,7 @@ void WebTabView::_DrawCloseButton(BView* owner, BRect& frame,
 
 	// Draw the ×
 	if (fClicked)
-		increaseContrastBy(tint, .2, base.Brightness());
+		IncreaseContrastBy(tint, .2, base.Brightness());
 	base = tint_color(base, tint);
 	owner->SetHighColor(base);
 	owner->SetPenSize(2);

--- a/src/helpers/tabview/TabManager.cpp
+++ b/src/helpers/tabview/TabManager.cpp
@@ -677,10 +677,17 @@ WebTabView::_CloseRectFrame(BRect frame) const
 }
 
 
-static void
-decrease_contrast(float& tint, const float& value, const int& brightness)
+static void inline
+decreaseContrastBy(float& tint, const float& value, const int& brightness)
 {
-	tint = tint * (1 + ((brightness >= 120) ? +1 : -1)*value);
+	tint *= 1 + ((brightness >= 120) ? -1 : +1) * value;
+}
+
+
+static void inline
+increaseContrastBy(float& tint, const float& value, const int& brightness)
+{
+	tint *= 1 + ((brightness >= 120) ? +1 : -1) * value;
 }
 
 
@@ -713,7 +720,7 @@ void WebTabView::_DrawCloseButton(BView* owner, BRect& frame,
 
 	// Draw the ×
 	if (fClicked)
-		decrease_contrast(tint, .2, base.Brightness());
+		increaseContrastBy(tint, .2, base.Brightness());
 	base = tint_color(base, tint);
 	owner->SetHighColor(base);
 	owner->SetPenSize(2);


### PR DESCRIPTION
Fix tab closing button with a dark panel background color.
Also use a rect around the "x" on hovering.