### PR TITLE
Select the file/folder that got "Show in Tracker"

### DIFF
--- a/src/ui/GenioWindow.h
+++ b/src/ui/GenioWindow.h
@@ -121,7 +121,7 @@ private:
 			void				_ProjectFolderActivate(ProjectFolder* project);
 
 			status_t			_ShowSelectedItemInTracker();
-			status_t			_ShowInTracker(const entry_ref& ref);
+			status_t			_ShowInTracker(const entry_ref& ref, const node_ref* nref = NULL);
 			status_t			_OpenTerminalWorkingDirectory();
 
 			int					_Replace(int what);


### PR DESCRIPTION
After invoking _ShowInTracker() to have a file/folder's parent folder opened in Tracker, select it. The users can then continue with what they intended with the file/folder without having to look for it in the opened parent folder.

There's a 0.3s delay in selecting the file/folder. This allows the just opened Tracker window to populate it, which may take a bit for folders with a huge number of files.
Project folders normally don't have hundreds of files crammed into a single folder, so this delay may be reduced after some testing.

Worst case, the file couldn't be selected, because Tracker was too slow loading all items.