### PR TITLE
Move creating the window from ReadyToRun() to GenioApp()

### DIFF
--- a/src/GenioApp.cpp
+++ b/src/GenioApp.cpp
@@ -54,6 +54,23 @@ GenioApp::GenioApp()
 	find_directory(B_USER_SETTINGS_DIRECTORY, &fConfigurationPath);
 	fConfigurationPath.Append(GenioNames::kApplicationName);
 	fConfigurationPath.Append(GenioNames::kSettingsFileName);
+
+	_PrepareConfig(gCFG);
+
+	// Global settings file check.
+	if (gCFG.LoadFromFile(fConfigurationPath) != B_OK) {
+		LogInfo("Cannot load global settings file");
+	}
+
+	Logger::SetDestination(gCFG["log_destination"]);
+	if (sSessionLogLevel == LOG_LEVEL_UNSET)
+		Logger::SetLevel(log_level(int32(gCFG["log_level"])));
+	else
+		Logger::SetLevel(sSessionLogLevel);
+
+	Languages::LoadLanguages();
+
+	fGenioWindow = new GenioWindow(gCFG["ui_bounds"]);
 }
 
 
@@ -198,25 +215,9 @@ GenioApp::RefsReceived(BMessage* message)
 void
 GenioApp::ReadyToRun()
 {
-	_PrepareConfig(gCFG);
-
-	// Global settings file check.
-	if (gCFG.LoadFromFile(fConfigurationPath) != B_OK) {
-		LogInfo("Cannot load global settings file");
-	}
-
 	// let's subscribe config changes updates
 	StartWatching(this, MSG_NOTIFY_CONFIGURATION_UPDATED);
 
-	Logger::SetDestination(gCFG["log_destination"]);
-	if (sSessionLogLevel == LOG_LEVEL_UNSET)
-		Logger::SetLevel(log_level(int32(gCFG["log_level"])));
-	else
-		Logger::SetLevel(sSessionLogLevel);
-
-	Languages::LoadLanguages();
-
-	fGenioWindow = new GenioWindow(gCFG["ui_bounds"]);
 	fGenioWindow->Show();
 }
 


### PR DESCRIPTION
RefsReceived() is called before ReadyToRun(). We pass the B_REFS_RECEIVED message to GenioWindow, and that didn't exist at that moment.

This fixes #235