### PR TITLE
Fix/overwrite

### DIFF
--- a/src/ui/EditorStatusView.cpp
+++ b/src/ui/EditorStatusView.cpp
@@ -153,6 +153,11 @@ StatusView::MouseDown(BPoint where)
 	if (where.x < fNavigationButtonWidth + fCellWidth[kPositionCell] && where.x > fNavigationButtonWidth) {
 		BMessenger msgr(Window());
 		msgr.SendMessage(MSG_GOTO_LINE);
+	} else if (where.x < fNavigationButtonWidth + fCellWidth[kPositionCell] + fCellWidth[kOverwriteMode] &&
+	           where.x > fNavigationButtonWidth + fCellWidth[kPositionCell]) {
+
+		BMessenger msgr(Window());
+		msgr.SendMessage(MSG_TEXT_OVERWRITE);
 	}
 }
 
@@ -185,11 +190,11 @@ StatusView::SetStatus(BMessage* message)
 		&& message->FindInt32("column", &column) == B_OK) {
 		fCellText[kPositionCell].SetToFormat("%" B_PRIi32 ":%" B_PRIi32, line, column);
 	}
-	
+
 	fCellText[kOverwriteMode] = message->GetString("overwrite", "");
 	fCellText[kLineFeed] 	  = message->GetString("eol", "");
 	fCellText[kFileStateCell] = message->GetString("readOnly", "");
-	
+
 	Invalidate();
 }
 

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -2506,7 +2506,7 @@ GenioWindow::_InitActions()
 								   "", "", 'A');
 	ActionManager::RegisterAction(MSG_TEXT_OVERWRITE,
 								   B_TRANSLATE("Overwrite"),
-								   "", "", B_INSERT);
+								   "", "");
 	ActionManager::RegisterAction(MSG_FILE_FOLD_TOGGLE,
 								   B_TRANSLATE("Fold/Unfold all"),
 								   B_TRANSLATE("Fold/Unfold all"),
@@ -2796,6 +2796,7 @@ GenioWindow::_InitMenu()
 	ActionManager::SetEnabled(B_PASTE, false);
 	ActionManager::SetEnabled(B_SELECT_ALL, false);
 	ActionManager::SetEnabled(MSG_TEXT_OVERWRITE, false);
+	ActionManager::SetPressed(MSG_TEXT_OVERWRITE, false);
 	ActionManager::SetEnabled(MSG_DUPLICATE_LINE, false);
 	ActionManager::SetEnabled(MSG_DELETE_LINES, false);
 	ActionManager::SetEnabled(MSG_COMMENT_SELECTED_LINES, false);
@@ -3859,7 +3860,7 @@ GenioWindow::_UpdateSavepointChange(Editor* editor, const BString& caller)
 
 	ActionManager::SetEnabled(B_UNDO, editor->CanUndo());
 	ActionManager::SetEnabled(B_REDO, editor->CanRedo());
-	ActionManager::SetPressed(B_INSERT, !editor->IsOverwrite());
+	ActionManager::SetPressed(MSG_TEXT_OVERWRITE, editor->IsOverwrite());
 
 	//ActionManager.
 	ActionManager::SetEnabled(MSG_FILE_SAVE, editor->IsModified());
@@ -3913,6 +3914,7 @@ GenioWindow::_UpdateTabChange(Editor* editor, const BString& caller)
 		ActionManager::SetEnabled(B_SELECT_ALL, false);
 
 		ActionManager::SetEnabled(MSG_TEXT_OVERWRITE, false);
+		ActionManager::SetPressed(MSG_TEXT_OVERWRITE, false);
 		ActionManager::SetEnabled(MSG_WHITE_SPACES_TOGGLE, false);
 		ActionManager::SetEnabled(MSG_LINE_ENDINGS_TOGGLE, false);
 
@@ -3973,6 +3975,7 @@ GenioWindow::_UpdateTabChange(Editor* editor, const BString& caller)
 	ActionManager::SetEnabled(B_SELECT_ALL, true);
 
 	ActionManager::SetEnabled(MSG_TEXT_OVERWRITE, true);
+	ActionManager::SetPressed(MSG_TEXT_OVERWRITE, editor->IsOverwrite());
 
 	ActionManager::SetEnabled(MSG_WHITE_SPACES_TOGGLE, true);
 	ActionManager::SetEnabled(MSG_LINE_ENDINGS_TOGGLE, true);

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -3859,6 +3859,7 @@ GenioWindow::_UpdateSavepointChange(Editor* editor, const BString& caller)
 
 	ActionManager::SetEnabled(B_UNDO, editor->CanUndo());
 	ActionManager::SetEnabled(B_REDO, editor->CanRedo());
+	ActionManager::SetPressed(B_INSERT, !editor->IsOverwrite());
 
 	//ActionManager.
 	ActionManager::SetEnabled(MSG_FILE_SAVE, editor->IsModified());


### PR DESCRIPTION
* the editor status view INS section can be clicked to switch to OVR
* the Overwrite menu is in sync with the current editor status
* remove the menu shorcut as it cannot be rendered by BMenuItem.