### PR TITLE
Fixed sporadic crash when deleting project outside of Genio

### DIFF
--- a/src/git/SourceControlPanel.cpp
+++ b/src/git/SourceControlPanel.cpp
@@ -60,7 +60,7 @@ SourceControlPanel::SourceControlPanel()
 	fProjectMenu(nullptr),
 	fBranchMenu(nullptr),
 	fProjectList(nullptr),
-	fSelectedProjectName(nullptr),
+	fSelectedProjectName(),
 	fCurrentBranch(nullptr),
 	fInitializeButton(nullptr),
 	fDoNotCreateInitialCommitCheckBox(nullptr),
@@ -282,7 +282,7 @@ SourceControlPanel::MessageReceived(BMessage *message)
 							fProjectMenu->MakeEmpty();
 							fBranchMenu->MakeEmpty();
 							fRepositoryView->MakeEmpty();
-							fSelectedProjectName = nullptr;
+							fSelectedProjectName = "";
 						} else {
 							_UpdateProjectList();
 						}
@@ -536,7 +536,7 @@ SourceControlPanel::MessageReceived(BMessage *message)
 					selectedProject->InitRepository(createInitialCommit);
 					SetChecked<BCheckBox>(fDoNotCreateInitialCommitCheckBox, false);
 					BMessage message(MsgChangeProject);
-					message.AddPointer("value", fSelectedProjectName);
+					message.AddPointer("value", selectedProject);
 					message.AddString("sender", kSenderInitializeRepositoryButton);
 					BMessenger(this).SendMessage(&message);
 				}
@@ -613,7 +613,7 @@ SourceControlPanel::_ChangeProject(BMessage *message)
 {
 	ProjectFolder* selectedProject = const_cast<ProjectFolder*>(
 		reinterpret_cast<const ProjectFolder*>(message->GetPointer("value")));
-	
+
 	fSelectedProjectName = "";
 	const BString sender = message->GetString("sender");	
 	if (selectedProject != nullptr) {
@@ -731,7 +731,7 @@ SourceControlPanel::_UpdateProjectList()
 		}
 	);
 	// Check if the selected project is a valid git repository
-	
+
 	ProjectFolder* project = _GetProject(fSelectedProjectName);
 	if (project != nullptr) {
 		try {

--- a/src/git/SourceControlPanel.cpp
+++ b/src/git/SourceControlPanel.cpp
@@ -291,7 +291,8 @@ SourceControlPanel::MessageReceived(BMessage *message)
 					case MSG_NOTIFY_PROJECT_SET_ACTIVE:
 					{
 						LogInfo("MSG_NOTIFY_PROJECT_SET_ACTIVE");
-						fSelectedProjectName = gMainWindow->GetActiveProject()->Name();
+						ProjectFolder* project = gMainWindow->GetActiveProject();
+						fSelectedProjectName = project ? project->Name() : "";
 						if (!fProjectList->IsEmpty())
 							_UpdateProjectList();
 						break;
@@ -332,7 +333,7 @@ SourceControlPanel::MessageReceived(BMessage *message)
 
 								// create a message to update the project
 								BMessage message(MsgChangeProject);
-								message.AddPointer("value", fSelectedProjectName);
+								message.AddPointer("value", selected);
 								message.AddString("sender", kSenderExternalEvent);
 								fBurstHandler = new BMessageRunner(BMessenger(this),
 									&message, kBurstTimeout, 1);

--- a/src/git/SourceControlPanel.cpp
+++ b/src/git/SourceControlPanel.cpp
@@ -60,7 +60,7 @@ SourceControlPanel::SourceControlPanel()
 	fProjectMenu(nullptr),
 	fBranchMenu(nullptr),
 	fProjectList(nullptr),
-	fSelectedProject(nullptr),
+	fSelectedProjectName(nullptr),
 	fCurrentBranch(nullptr),
 	fInitializeButton(nullptr),
 	fDoNotCreateInitialCommitCheckBox(nullptr),
@@ -282,7 +282,7 @@ SourceControlPanel::MessageReceived(BMessage *message)
 							fProjectMenu->MakeEmpty();
 							fBranchMenu->MakeEmpty();
 							fRepositoryView->MakeEmpty();
-							fSelectedProject = nullptr;
+							fSelectedProjectName = nullptr;
 						} else {
 							_UpdateProjectList();
 						}
@@ -291,58 +291,60 @@ SourceControlPanel::MessageReceived(BMessage *message)
 					case MSG_NOTIFY_PROJECT_SET_ACTIVE:
 					{
 						LogInfo("MSG_NOTIFY_PROJECT_SET_ACTIVE");
-						fSelectedProject = gMainWindow->GetActiveProject();
+						fSelectedProjectName = gMainWindow->GetActiveProject()->Name();
 						if (!fProjectList->IsEmpty())
 							_UpdateProjectList();
 						break;
 					}
 					case B_PATH_MONITOR:
 					{
-						if (fSelectedProject == nullptr)
+						if (fProjectList->IsEmpty())
 							break;
-						if (!fSelectedProject->IsBuilding()) {
-							LogInfo("B_PATH_MONITOR");
-							BString watchedPath;
-							if (message->FindString("watched_path", &watchedPath) != B_OK)
-								return;
 
-							// check if the project folder still exists
-							if (!BEntry(fSelectedProject->EntryRef()).Exists())
-								return;
-							BString projectPath = fSelectedProject->Path();
-							if (watchedPath == projectPath) {
-								BString path;
-								if (message->FindString("path", &path) != B_OK)
-									return;
+						ProjectFolder* selected = _GetProject(fSelectedProjectName);
+						if (selected == nullptr || selected->IsBuilding())
+							break;
+							
+						LogInfo("B_PATH_MONITOR");
+						BString watchedPath;
+						if (message->FindString("watched_path", &watchedPath) != B_OK)
+							break;
+						const BString projectPath = selected->Path();
+						if (watchedPath != projectPath)
+							break;
+						// check if the project folder still exists
+						if (!BEntry(projectPath).Exists())
+							break;
+						BString path;
+						if (message->FindString("path", &path) != B_OK)
+							break;
 
-								BPath gitFolder(fSelectedProject->Path());
-								gitFolder.Append(".git");
+						BPath gitFolder(projectPath);
+						gitFolder.Append(".git");
+						
+						// TODO: Move the burst handler to a function
+						if (path.FindFirst(gitFolder.Path()) != B_ERROR) {
+							if (fBurstHandler == nullptr ||
+								fBurstHandler->SetInterval(kBurstTimeout) != B_OK) {
+								LogInfo("SourceControlPanel: fBurstHandler not valid");
+								if (fBurstHandler != nullptr)
+									delete fBurstHandler;
 
-								if (path.FindFirst(gitFolder.Path()) != B_ERROR) {
-									if (fBurstHandler == nullptr ||
-										fBurstHandler->SetInterval(kBurstTimeout) != B_OK) {
-										LogInfo("SourceControlPanel: fBurstHandler not valid");
-
-										if (fBurstHandler != nullptr)
-											delete fBurstHandler;
-
-										// create a message to update the project
-										BMessage message(MsgChangeProject);
-										message.AddPointer("value", fSelectedProject);
-										message.AddString("sender", kSenderExternalEvent);
-										fBurstHandler = new BMessageRunner(BMessenger(this),
-											&message, kBurstTimeout, 1);
-										if (fBurstHandler->InitCheck() != B_OK) {
-											LogInfo("SourceControlPanel: Could not create "
-												"fBurstHandler. Deleting it");
-											if (fBurstHandler != nullptr) {
-												delete fBurstHandler;
-												fBurstHandler = nullptr;
-											}
-										} else {
-											LogInfo("SourceControlPanel: fBurstHandler instantiated.");
-										}
+								// create a message to update the project
+								BMessage message(MsgChangeProject);
+								message.AddPointer("value", fSelectedProjectName);
+								message.AddString("sender", kSenderExternalEvent);
+								fBurstHandler = new BMessageRunner(BMessenger(this),
+									&message, kBurstTimeout, 1);
+								if (fBurstHandler->InitCheck() != B_OK) {
+									LogInfo("SourceControlPanel: Could not create "
+										"fBurstHandler. Deleting it");
+									if (fBurstHandler != nullptr) {
+										delete fBurstHandler;
+										fBurstHandler = nullptr;
 									}
+								} else {
+									LogInfo("SourceControlPanel: fBurstHandler instantiated.");
 								}
 							}
 						}
@@ -383,21 +385,29 @@ SourceControlPanel::MessageReceived(BMessage *message)
 			}
 			case MsgFetch: {
 				LogInfo("MsgFetch");
-				fSelectedProject->GetRepository()->Fetch();
+				ProjectFolder* selectedProject = _GetProject(fSelectedProjectName);
+				if (selectedProject == nullptr)
+					break;
+				selectedProject->GetRepository()->Fetch();
 				_ShowGitNotification(B_TRANSLATE("Fetch completed."));
 				_UpdateBranchList();
 				break;
 			}
 			case MsgFetchPrune: {
 				LogInfo("MsgFetchPrune");
-				fSelectedProject->GetRepository()->Fetch(true);
+				ProjectFolder* selectedProject = _GetProject(fSelectedProjectName);
+				if (selectedProject == nullptr)
+					break;
+				selectedProject->GetRepository()->Fetch(true);
 				_ShowGitNotification(B_TRANSLATE("Fetch prune completed."));
 				_UpdateBranchList();
 				break;
 			}
 			case MsgStashSave: {
 				LogInfo("MsgStashSave");
-
+				ProjectFolder* selectedProject = _GetProject(fSelectedProjectName);
+				if (selectedProject == nullptr)
+					break;
 				BString stashMessage;
 				stashMessage << "WIP on " << fCurrentBranch << B_UTF8_ELLIPSIS;
 				auto alert = new GTextAlert("Stash", B_TRANSLATE("Enter a message for this stash"),
@@ -405,20 +415,26 @@ SourceControlPanel::MessageReceived(BMessage *message)
 				auto result = alert->Go();
 				if (result.Button == GAlertButtons::OkButton) {
 					stashMessage = result.Result;
-					fSelectedProject->GetRepository()->StashSave(stashMessage);
+					selectedProject->GetRepository()->StashSave(stashMessage);
 					_ShowGitNotification(B_TRANSLATE("Changes stashed."));
 				}
 				break;
 			}
 			case MsgStashPop: {
 				LogInfo("MsgStashPop");
-				fSelectedProject->GetRepository()->StashPop();
+				ProjectFolder* selectedProject = _GetProject(fSelectedProjectName);
+				if (selectedProject == nullptr)
+					break;
+				selectedProject->GetRepository()->StashPop();
 				_ShowGitNotification(B_TRANSLATE("Stashed changes popped."));
 				break;
 			}
 			case MsgStashApply: {
 				LogInfo("MsgStashApply");
-				fSelectedProject->GetRepository()->StashApply();
+				ProjectFolder* selectedProject = _GetProject(fSelectedProjectName);
+				if (selectedProject == nullptr)
+					break;
+				selectedProject->GetRepository()->StashApply();
 				_ShowGitNotification(B_TRANSLATE("Stashed changes applied."));
 				break;
 			}
@@ -431,13 +447,16 @@ SourceControlPanel::MessageReceived(BMessage *message)
 				break;
 			}
 			case MsgRenameBranch: {
+				ProjectFolder* selectedProject = _GetProject(fSelectedProjectName);
+				if (selectedProject == nullptr)
+					break;
 				BString selectedBranch = message->GetString("value");
 				git_branch_t branchType = static_cast<git_branch_t>(message->GetInt32("type",-1));
 				auto alert = new GTextAlert(B_TRANSLATE("Rename branch"),
 					B_TRANSLATE("Rename branch:"), selectedBranch);
 				auto result = alert->Go();
 				if (result.Button == GAlertButtons::OkButton) {
-					auto repo = fSelectedProject->GetRepository();
+					auto repo = selectedProject->GetRepository();
 					repo->RenameBranch(selectedBranch, result.Result, branchType);
 					_UpdateBranchList();
 					LogInfo("MsgRenameBranch: %s renamed to %s", selectedBranch.String(),
@@ -446,6 +465,9 @@ SourceControlPanel::MessageReceived(BMessage *message)
 				break;
 			}
 			case MsgDeleteBranch: {
+				ProjectFolder* selectedProject = _GetProject(fSelectedProjectName);
+				if (selectedProject == nullptr)
+					break;
 				const BString selectedBranch = message->GetString("value");
 				StringFormatter fmt;
 				fmt.Substitutions["%branch%"] = selectedBranch;
@@ -461,7 +483,7 @@ SourceControlPanel::MessageReceived(BMessage *message)
 				int32 choice = alert->Go();
 				if (choice == 1) {
 					git_branch_t branchType = static_cast<git_branch_t>(message->GetInt32("type",-1));
-					auto repo = fSelectedProject->GetRepository();
+					auto repo = selectedProject->GetRepository();
 					repo->DeleteBranch(selectedBranch, branchType);
 					_UpdateBranchList();
 					LogInfo("MsgDeleteBranch: %s", selectedBranch.String());
@@ -469,6 +491,9 @@ SourceControlPanel::MessageReceived(BMessage *message)
 				break;
 			}
 			case MsgNewBranch: {
+				ProjectFolder* selectedProject = _GetProject(fSelectedProjectName);
+				if (selectedProject == nullptr)
+					break;
 				const BString selectedBranch = message->GetString("value");
 				BString newLocalName(selectedBranch);
 				newLocalName.RemoveAll("origin/");
@@ -477,7 +502,7 @@ SourceControlPanel::MessageReceived(BMessage *message)
 					B_TRANSLATE("Rename branch:"), selectedBranch);
 				auto result = alert->Go();
 				if (result.Button == GAlertButtons::OkButton) {
-					auto repo = fSelectedProject->GetRepository();
+					auto repo = selectedProject->GetRepository();
 					repo->CreateBranch(selectedBranch, branchType, result.Result);
 					LogInfo("MsgRenameBranch: %s created from %s", selectedBranch.String(),
 						result.Result.String());
@@ -491,7 +516,10 @@ SourceControlPanel::MessageReceived(BMessage *message)
 				break;
 			}
 			case MsgInitializeRepository: {
-				auto repo = fSelectedProject->GetRepository();
+				ProjectFolder* selectedProject = _GetProject(fSelectedProjectName);
+				if (selectedProject == nullptr)
+					break;
+				auto repo = selectedProject->GetRepository();
 				if (!repo->IsInitialized()) {
 					auto createInitialCommit = !IsChecked<BCheckBox>(fDoNotCreateInitialCommitCheckBox);
 					if (!createInitialCommit) {
@@ -505,10 +533,10 @@ SourceControlPanel::MessageReceived(BMessage *message)
 						if (choice == 0)
 							return;
 					}
-					fSelectedProject->InitRepository(createInitialCommit);
+					selectedProject->InitRepository(createInitialCommit);
 					SetChecked<BCheckBox>(fDoNotCreateInitialCommitCheckBox, false);
 					BMessage message(MsgChangeProject);
-					message.AddPointer("value", fSelectedProject);
+					message.AddPointer("value", fSelectedProjectName);
 					message.AddString("sender", kSenderInitializeRepositoryButton);
 					BMessenger(this).SendMessage(&message);
 				}
@@ -532,7 +560,7 @@ SourceControlPanel::MessageReceived(BMessage *message)
 			// Pull must be fixed and is disabled
 			// case MsgPull: {
 				// auto selectedBranch = BString(message->GetString("selectedBranch"));
-				// auto result = fSelectedProject->GetRepository()->Pull(selectedBranch);
+				// auto result = fSelectedProjectName->GetRepository()->Pull(selectedBranch);
 				// switch (result) {
 					// case PullResult::UpToDate: {
 						// _ShowGitNotification(B_TRANSLATE("The branch is up to date."));
@@ -554,7 +582,7 @@ SourceControlPanel::MessageReceived(BMessage *message)
 			// Pull rebase is seriously flawed. We disable this until we get it work properly
 			// case MsgPullRebase: {
 				// auto selectedBranch = BString(message->GetString("selectedBranch"));
-				// fSelectedProject->GetRepository()->PullRebase();
+				// fSelectedProjectName->GetRepository()->PullRebase();
 				// _ShowGitNotification(B_TRANSLATE("Pull rebase completed."));
 				// LogInfo("MsgPullRebase: %s", selectedBranch.String());
 				// break;
@@ -583,16 +611,18 @@ SourceControlPanel::MessageReceived(BMessage *message)
 void
 SourceControlPanel::_ChangeProject(BMessage *message)
 {
-	fSelectedProject = const_cast<ProjectFolder*>(
+	ProjectFolder* selectedProject = const_cast<ProjectFolder*>(
 		reinterpret_cast<const ProjectFolder*>(message->GetPointer("value")));
-	const BString sender = message->GetString("sender");
 	
-	if (fSelectedProject != nullptr) {
+	fSelectedProjectName = "";
+	const BString sender = message->GetString("sender");	
+	if (selectedProject != nullptr) {
+		fSelectedProjectName = selectedProject->Name();
 		// check if the project folder still exists
-		if (!BEntry(fSelectedProject->EntryRef()).Exists())
+		if (!BEntry(selectedProject->EntryRef()).Exists())
 			return;
 		// Check if the selected project is a valid git repository
-		auto repo = fSelectedProject->GetRepository();
+		auto repo = selectedProject->GetRepository();
 		if (repo->IsInitialized()) {
 			if (sender == kSenderInitializeRepositoryButton ||
 				sender == kSenderProjectOptionList ||
@@ -601,31 +631,51 @@ SourceControlPanel::_ChangeProject(BMessage *message)
 					_UpdateBranchList(false);
 					_UpdateRepositoryView();
 				} catch(const GitException &ex) {
-					LogInfo(" %s repository has no valid info", fSelectedProject->Name().String());
+					LogInfo(" %s repository has no valid info", fSelectedProjectName.String());
 				}
 				fMainLayout->SetVisibleItem(kMainIndexRepository);
 			}
 		} else {
 			fMainLayout->SetVisibleItem(kMainIndexInitialize);
 		}
-		LogInfo("Project changed to %s", fSelectedProject->Name().String());
+		LogInfo("Project changed to %s", fSelectedProjectName.String());
 	} else {
 		LogError("Fatal error: ProjectFolder not valid");
 	}
 }
 
 
+ProjectFolder*
+SourceControlPanel::_GetProject(const BString& name) const
+{
+	// TODO: terribly awkward.
+	// Luckily we fixed this in the main branch
+	GenioWindow* window = static_cast<GenioWindow*>(Window());
+	if (window == nullptr)
+		return nullptr;
+	ProjectsFolderBrowser* projectBrowser = window->GetProjectBrowser();
+	if (projectBrowser == nullptr)
+		return nullptr;
+	ProjectItem* selectedProjectItem = projectBrowser->GetProjectItem(fSelectedProjectName);
+	if (selectedProjectItem == nullptr)
+		return nullptr;
+	return projectBrowser->GetProjectFromItem(selectedProjectItem);
+}
+
+
 void
 SourceControlPanel::_UpdateRepositoryView()
 {
-	fRepositoryView->UpdateRepository(fSelectedProject, fCurrentBranch);
+	ProjectFolder* project = _GetProject(fSelectedProjectName);
+	fRepositoryView->UpdateRepository(project, fCurrentBranch);
 }
 
 
 void
 SourceControlPanel::_SwitchBranch(BMessage *message)
 {
-	if (fSelectedProject->IsBuilding()) {
+	ProjectFolder* project = _GetProject(fSelectedProjectName);
+	if (project->IsBuilding()) {
 		OKAlert("Source control panel",
 			B_TRANSLATE("The project is building, changing branch not allowed."),
 			B_STOP_ALERT);
@@ -633,7 +683,7 @@ SourceControlPanel::_SwitchBranch(BMessage *message)
 		const BString branch = message->GetString("value");
 		const BString sender = message->GetString("sender");
 
-		auto repo = fSelectedProject->GetRepository();
+		auto repo = project->GetRepository();
 		repo->SwitchBranch(branch);
 		fCurrentBranch = repo->GetCurrentBranch();
 
@@ -653,16 +703,17 @@ void
 SourceControlPanel::_UpdateProjectList()
 {
 	if (fProjectList == nullptr) {
-		fSelectedProject = nullptr;
+		fSelectedProjectName = "";
 		return;
 	}
 
 	fProjectMenu->SetTarget(this);
 	fProjectMenu->SetSender(kSenderProjectOptionList);
-	ProjectFolder* selectedProject = fSelectedProject;
+	ProjectFolder* selectedProject = _GetProject(fSelectedProjectName);
 	fProjectMenu->MakeEmpty();
-	fSelectedProject = nullptr;
+	fSelectedProjectName = "";
 	ProjectFolder* activeProject = gMainWindow->GetActiveProject();
+	// TODO: We should compare names instead of pointers
 	fProjectMenu->AddList(fProjectList,
 		MsgChangeProject,
 		[&active = activeProject](auto item)
@@ -680,9 +731,11 @@ SourceControlPanel::_UpdateProjectList()
 		}
 	);
 	// Check if the selected project is a valid git repository
-	if (fSelectedProject != nullptr) {
+	
+	ProjectFolder* project = _GetProject(fSelectedProjectName);
+	if (project != nullptr) {
 		try {
-			GitRepository* repo = fSelectedProject->GetRepository();
+			GitRepository* repo = project->GetRepository();
 			if (repo->IsInitialized()) {
 				_UpdateBranchList();
 			} else {
@@ -700,8 +753,9 @@ void
 SourceControlPanel::_UpdateBranchList(bool invokeItemMessage)
 {
 	try {
-		if (fSelectedProject != nullptr) {
-			auto repo = fSelectedProject->GetRepository();
+		ProjectFolder* selectedProject = _GetProject(fSelectedProjectName);
+		if (selectedProject != nullptr) {
+			auto repo = selectedProject->GetRepository();
 			if (repo->IsInitialized()) {
 				auto branches = repo->GetBranches();
 				fCurrentBranch = repo->GetCurrentBranch();
@@ -764,7 +818,10 @@ SourceControlPanel::_ShowOptionsMenu(BPoint where)
 void
 SourceControlPanel::_ShowGitNotification(const BString &text)
 {
-	ShowNotification("Genio", fSelectedProject->Path().String(),
-		fSelectedProject->Path().String(),
+	ProjectFolder* project = _GetProject(fSelectedProjectName);
+	if (project == nullptr)
+		return;
+	ShowNotification("Genio", project->Path().String(),
+		project->Path().String(),
 		text);
 }

--- a/src/git/SourceControlPanel.h
+++ b/src/git/SourceControlPanel.h
@@ -70,12 +70,13 @@ private:
 	BView*					fLogView;
 	BView*					fRepositoryNotInitializedView;
 	BObjectList<ProjectFolder>* fProjectList;
-	ProjectFolder*			fSelectedProject;
+	BString					fSelectedProjectName;
 	BString					fCurrentBranch;
 	BButton*				fInitializeButton;
 	BCheckBox*				fDoNotCreateInitialCommitCheckBox;
 	BMessageRunner*			fBurstHandler;
 
+	ProjectFolder*			_GetProject(const BString& name) const;
 	void					_UpdateProjectList();
 	void					_UpdateBranchList(bool invokeItemMessage = true);
 

--- a/src/git/SourceControlPanel.h
+++ b/src/git/SourceControlPanel.h
@@ -70,13 +70,13 @@ private:
 	BView*					fLogView;
 	BView*					fRepositoryNotInitializedView;
 	BObjectList<ProjectFolder>* fProjectList;
-	BString					fSelectedProjectName;
+	BString					fSelectedProjectPath;
 	BString					fCurrentBranch;
 	BButton*				fInitializeButton;
 	BCheckBox*				fDoNotCreateInitialCommitCheckBox;
 	BMessageRunner*			fBurstHandler;
 
-	ProjectFolder*			_GetProject(const BString& name) const;
+	ProjectFolder*			_GetSelectedProject() const;
 	void					_UpdateProjectList();
 	void					_UpdateBranchList(bool invokeItemMessage = true);
 


### PR DESCRIPTION
SourceControlPanel: Don't keep a ProjectFolder pointer: it can become invalid in certain circumstances. Keep the project path instead, and only get the pointer when it needs to be used. Also check the pointer for nullptr.

I only tested briefly but there seems to be no regressions

Fixes #240 (only in release branch)