### PR TITLE
Small refactor

### DIFF
--- a/src/git/SourceControlPanel.cpp
+++ b/src/git/SourceControlPanel.cpp
@@ -649,23 +649,14 @@ SourceControlPanel::_ChangeProject(BMessage *message)
 ProjectFolder*
 SourceControlPanel::_GetSelectedProject() const
 {
-	// TODO: terribly awkward.
-	// Luckily we fixed this in the main branch
 	GenioWindow* window = static_cast<GenioWindow*>(Window());
 	if (window == nullptr)
 		return nullptr;
 	ProjectsFolderBrowser* projectBrowser = window->GetProjectBrowser();
 	if (projectBrowser == nullptr)
 		return nullptr;
-	// search the ProjectFolder by path
-	// TODO: implement in ProjectFolderBrowser
-	for (int32 i = 0; i < projectBrowser->CountProjects(); i++) {
-		ProjectFolder* project = projectBrowser->ProjectAt(i);
-		if (project != nullptr && project->Path() == fSelectedProjectPath)
-			return project;
-	}
 
-	return nullptr;
+	return projectBrowser->ProjectByPath(fSelectedProjectPath);
 }
 
 

--- a/src/ui/ProjectsFolderBrowser.cpp
+++ b/src/ui/ProjectsFolderBrowser.cpp
@@ -795,17 +795,32 @@ ProjectsFolderBrowser::InitRename(ProjectItem *item)
 	Invalidate();
 }
 
+
 int32
 ProjectsFolderBrowser::CountProjects() const
 {
 	return fProjectList.CountItems();
 }
 
+
 ProjectFolder*
 ProjectsFolderBrowser::ProjectAt(int32 index) const
 {
 	return fProjectList.ItemAt(index);
 }
+
+
+ProjectFolder*
+ProjectsFolderBrowser::ProjectByPath(const BString& fullPath) const
+{
+	for (int32 i = 0; i < CountProjects(); i++) {
+		ProjectFolder* project = ProjectAt(i);
+		if (project != nullptr && project->Path() == fullPath)
+			return project;
+	}
+	return nullptr;
+}
+
 
 const BObjectList<ProjectFolder>*
 ProjectsFolderBrowser::GetProjectList() const

--- a/src/ui/ProjectsFolderBrowser.h
+++ b/src/ui/ProjectsFolderBrowser.h
@@ -56,9 +56,9 @@ public:
 
 	int32			CountProjects() const;
 	ProjectFolder*	ProjectAt(int32 index) const;
+	ProjectFolder*	ProjectByPath(const BString& fullPath) const;
 
 	const BObjectList<ProjectFolder>*	GetProjectList() const;
-
 private:
 
 	ProjectItem*	GetProjectItemByPath(const BString& path) const;


### PR DESCRIPTION
Implement ProjectFolderBrowser::ProjectByPath() and used in SourceControlPanel::_GetSelectedProject(). No functional change