### PR TITLE
Fix a crash when creating a new file from a template

### DIFF
--- a/src/git/SourceControlPanel.cpp
+++ b/src/git/SourceControlPanel.cpp
@@ -305,7 +305,7 @@ SourceControlPanel::MessageReceived(BMessage *message)
 						ProjectFolder* selected = _GetSelectedProject();
 						if (selected == nullptr || selected->IsBuilding())
 							break;
-							
+
 						LogInfo("B_PATH_MONITOR");
 						BString watchedPath;
 						if (message->FindString("watched_path", &watchedPath) != B_OK)
@@ -616,7 +616,7 @@ SourceControlPanel::_ChangeProject(BMessage *message)
 		reinterpret_cast<const ProjectFolder*>(message->GetPointer("value")));
 
 	fSelectedProjectPath = "";
-	const BString sender = message->GetString("sender");	
+	const BString sender = message->GetString("sender");
 	if (selectedProject != nullptr) {
 		fSelectedProjectPath = selectedProject->Path();
 		// check if the project folder still exists
@@ -725,15 +725,18 @@ SourceControlPanel::_UpdateProjectList()
 		[&active = activeProject](auto item)
 		{
 			BString projectName = item ? item->Name() : "";
-			if (active != nullptr &&
-				active->Name() == projectName)
+			BString projectPath = item ? item->Path() : "";
+			if (active != nullptr && active->Path() == projectPath)
 				projectName.Append("*");
 			return projectName;
 		},
 		true,
 		[&selected = selectedProject](auto item)
 		{
-			return (item == selected);
+			if (item == nullptr || selected == nullptr)
+				return false;
+			else
+				return (item->Path() == selected->Path());
 		}
 	);
 	// Check if the selected project is a valid git repository

--- a/src/git/SourceControlPanel.cpp
+++ b/src/git/SourceControlPanel.cpp
@@ -26,6 +26,8 @@
 #include "GenioApp.h"
 #include "GenioWindow.h"
 #include "GenioWindowMessages.h"
+#include "GitAlert.h"
+#include "GTextAlert.h"
 #include "Log.h"
 #include "ProjectFolder.h"
 #include "ProjectsFolderBrowser.h"
@@ -33,8 +35,6 @@
 #include "StringFormatter.h"
 #include "Utils.h"
 
-#include "GitAlert.h"
-#include "GTextAlert.h"
 
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "SourceControlPanel"
@@ -735,8 +735,7 @@ SourceControlPanel::_UpdateProjectList()
 		{
 			if (item == nullptr || selected == nullptr)
 				return false;
-			else
-				return (item->Path() == selected->Path());
+			return (item->Path() == selected->Path());
 		}
 	);
 	// Check if the selected project is a valid git repository

--- a/src/templates/TemplateManager.cpp
+++ b/src/templates/TemplateManager.cpp
@@ -51,9 +51,9 @@ TemplateManager::CopyFileTemplate(const entry_ref* source, const entry_ref* dest
 	if (status != B_OK) {
 		BString err(strerror(status));
 		LogError("Error creating new file %s in %s: %s", sourcePath.Path(), destPath.Path(),err.String());
+	} else {
+		FSChmod(destPath.Path(), fs::perms::all);
 	}
-
-	FSChmod(destPath.Path(), fs::perms::all);
 
 	return status;
 }
@@ -74,11 +74,11 @@ TemplateManager::CopyProjectTemplate(const entry_ref* source, const entry_ref* d
 	if (status != B_OK) {
 		BString err(strerror(status));
 		LogError("Error creating new template %s in %s: %s", sourcePath.Path(), destPath.Path(),err.String());
+	} else {
+		// TODO: Default templates in a tipical HPKG installation are readonly
+		// we are setting all permissions recursively here
+		FSChmod(destPath.Path(), fs::perms::all, true);
 	}
-
-	// TODO: Default templates in a tipical HPKG installation are readonly
-	// we are setting all permissions recursively here
-	FSChmod(destPath.Path(), fs::perms::all, true);
 
 	return status;
 }

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -861,21 +861,20 @@ GenioWindow::MessageReceived(BMessage* message)
 
 			// new_file_template corresponds to creating a new file
 			if (type ==  "new_file_template") {
-				entry_ref dest;
 				entry_ref source;
 				ProjectItem* item = fProjectsFolderBrowser->GetSelectedProjectItem();
 				if (item && item->GetSourceItem()->Type() != SourceItemType::FileItem) {
-					const entry_ref* entryRef = item->GetSourceItem()->EntryRef();
+					const entry_ref* dest = item->GetSourceItem()->EntryRef();
 					if (message->FindRef("refs", &source) != B_OK) {
 						LogError("Can't find ref in message!");
 						return;
 					}
-					status_t status = TemplateManager::CopyFileTemplate(&source, &dest);
+					status_t status = TemplateManager::CopyFileTemplate(&source, dest);
 					if (status != B_OK) {
 						OKAlert(B_TRANSLATE("New file"),
 								B_TRANSLATE("Could not create a new file"),
 								B_WARNING_ALERT);
-						LogError("Invalid destination directory [%s]", entryRef->name);
+						LogError("Invalid destination directory [%s]", dest->name);
 						return;
 					}
 				}


### PR DESCRIPTION
Fix a problem where there might be two different projects marked as as active if they have the same name.
Also fix a crash when creating a new file from a template

Fixes #262 and #250