### PR TITLE
Implement colored tabs

### DIFF
--- a/src/config/ConfigWindow.cpp
+++ b/src/config/ConfigWindow.cpp
@@ -114,6 +114,21 @@ void GControl<BOptionPopUp, const char*>::LoadValue(const char* value)
 }
 
 
+template<>
+GControl<BColorControl, rgb_color>::GControl(GMessage& msg, rgb_color value, ConfigManager& cfg)
+	:
+	BColorControl(B_ORIGIN,	B_CELLS_16x16, 16, ""),
+	fConfigManager(cfg)
+{
+	BColorControl::SetName(msg["key"]);
+	BColorControl::SetLabel(msg["label"]);
+	LoadValue(value);
+
+	GMessage* invoke = new GMessage(kOnNewValue);
+	(*invoke)["key"] = msg["key"];
+	BColorControl::SetMessage(invoke);
+}
+
 
 ConfigWindow::ConfigWindow(ConfigManager &configManager)
     : BWindow(BRect(100, 100, 700, 500), B_TRANSLATE("Settings"), B_TITLED_WINDOW_LOOK, B_MODAL_APP_WINDOW_FEEL,
@@ -378,10 +393,11 @@ ConfigWindow::MakeControlFor(GMessage& config)
 				return control;
 			}
 		}
-#if 0
+#if 1
 		case B_RGB_COLOR_TYPE:
 		{
-			GControl<BColorControl, rgb_color>* control = new GControl<BColorControl, rgb_color>(config, fConfigManager[config["key"]], fConfigManager);
+			GControl<BColorControl, rgb_color>* control =
+				new GControl<BColorControl, rgb_color>(config, fConfigManager[config["key"]], fConfigManager);
 			// TODO: Improve
 			return control;
 		}

--- a/src/config/ConfigWindow.cpp
+++ b/src/config/ConfigWindow.cpp
@@ -401,15 +401,12 @@ ConfigWindow::MakeControlFor(GMessage& config)
 				return control;
 			}
 		}
-#if 1
 		case B_RGB_COLOR_TYPE:
 		{
 			GControl<BColorControl, rgb_color>* control =
 				new GControl<BColorControl, rgb_color>(config, fConfigManager[config["key"]], fConfigManager);
-			// TODO: Improve
 			return control;
 		}
-#endif
 		default:
 		{
 			BString label;

--- a/src/config/ConfigWindow.cpp
+++ b/src/config/ConfigWindow.cpp
@@ -114,6 +114,7 @@ void GControl<BOptionPopUp, const char*>::LoadValue(const char* value)
 }
 
 
+// BColorControl
 template<>
 GControl<BColorControl, rgb_color>::GControl(GMessage& msg, rgb_color value, ConfigManager& cfg)
 	:
@@ -127,6 +128,13 @@ GControl<BColorControl, rgb_color>::GControl(GMessage& msg, rgb_color value, Con
 	GMessage* invoke = new GMessage(kOnNewValue);
 	(*invoke)["key"] = msg["key"];
 	BColorControl::SetMessage(invoke);
+}
+
+
+template<>
+rgb_color GControl<BColorControl, rgb_color>::RetrieveValue()
+{
+       return BColorControl::ValueAsColor();
 }
 
 

--- a/src/config/ConfigWindow.cpp
+++ b/src/config/ConfigWindow.cpp
@@ -118,7 +118,7 @@ void GControl<BOptionPopUp, const char*>::LoadValue(const char* value)
 template<>
 GControl<BColorControl, rgb_color>::GControl(GMessage& msg, rgb_color value, ConfigManager& cfg)
 	:
-	BColorControl(B_ORIGIN,	B_CELLS_16x16, 16, ""),
+	BColorControl(B_ORIGIN,	B_CELLS_32x8, 8, ""),
 	fConfigManager(cfg)
 {
 	BColorControl::SetName(msg["key"]);

--- a/src/config/ConfigWindow.cpp
+++ b/src/config/ConfigWindow.cpp
@@ -10,6 +10,7 @@
 #include <CardView.h>
 #include <Catalog.h>
 #include <CheckBox.h>
+#include <ColorControl.h>
 #include <LayoutBuilder.h>
 #include <OptionPopUp.h>
 #include <OutlineListView.h>
@@ -111,6 +112,7 @@ void GControl<BOptionPopUp, const char*>::LoadValue(const char* value)
 	}
 	SetValue(intValue);
 }
+
 
 
 ConfigWindow::ConfigWindow(ConfigManager &configManager)
@@ -376,6 +378,14 @@ ConfigWindow::MakeControlFor(GMessage& config)
 				return control;
 			}
 		}
+#if 0
+		case B_RGB_COLOR_TYPE:
+		{
+			GControl<BColorControl, rgb_color>* control = new GControl<BColorControl, rgb_color>(config, fConfigManager[config["key"]], fConfigManager);
+			// TODO: Improve
+			return control;
+		}
+#endif
 		default:
 		{
 			BString label;

--- a/src/config/GMessage.h
+++ b/src/config/GMessage.h
@@ -42,11 +42,11 @@
 
 #define KV(T) kv_pair(const std::string &k, T v) : pair(k, std::make_shared<mapped_type>(v)) {}
 
-#define SUPPORTED_1		int32, bool, const char*, BString, GMessage
+#define SUPPORTED_1		int32, bool, const char*, BString, GMessage, rgb_color
 #if __HAIKU_BEOS_COMPATIBLE_TYPES
 #define SUPPORTED_2		KV(int); KV(int32); KV(bool); KV(const char*); KV(BString); KV(GMessage);
 #else
-#define SUPPORTED_2		KV(int32); KV(bool); KV(const char*); KV(BString); KV(GMessage);
+#define SUPPORTED_2		KV(int32); KV(bool); KV(const char*); KV(BString); KV(GMessage); KV(rgb_color);
 #endif
 
 class GMessageReturn;

--- a/src/helpers/tabview/TabContainerView.cpp
+++ b/src/helpers/tabview/TabContainerView.cpp
@@ -18,7 +18,6 @@
 #include <SpaceLayoutItem.h>
 #include <Window.h>
 
-#include <iostream>
 #include <cassert>
 
 #include "TabView.h"
@@ -235,7 +234,6 @@ TabContainerView::MouseUp(BPoint where)
 	// it with fMouseDown == true.
 	_SendFakeMouseMoved();
 
-
 	Draggable::OnMouseUp(where);
 	if (fDropTargetHighlightFrame.IsValid()) {
 		Invalidate(fDropTargetHighlightFrame);
@@ -247,8 +245,7 @@ bool
 TabContainerView::InitiateDrag(BPoint where)
 {
 	TabView* tab = _TabAt(where);
-	if (tab != nullptr)
-	{
+	if (tab != nullptr) {
 		BMessage message(TAB_DRAG);
 		message.AddPointer("container", this);
 		message.AddInt32("index", IndexOf(tab));
@@ -274,14 +271,11 @@ TabContainerView::InitiateDrag(BPoint where)
 			int32 height = (int32)dragBitmap->Bounds().Height() + 1;
 			int32 width = (int32)dragBitmap->Bounds().Width() + 1;
 			int32 bpr = dragBitmap->BytesPerRow();
-
-
-				for (int32 y = 0; y < height; y++, bits += bpr) {
-					uint8* line = bits + 3;
-					for (uint8* end = line + 4 * width; line < end; line += 4)
-						*line = ALPHA;
-
-				}
+			for (int32 y = 0; y < height; y++, bits += bpr) {
+				uint8* line = bits + 3;
+				for (uint8* end = line + 4 * width; line < end; line += 4)
+					*line = ALPHA;
+			}
 			dragBitmap->Unlock();
 		} else {
 			delete dragBitmap;
@@ -303,8 +297,7 @@ void
 TabContainerView::MouseMoved(BPoint where, uint32 transit,
 	const BMessage* dragMessage)
 {
-	if (dragMessage && dragMessage->what == TAB_DRAG)
-	{
+	if (dragMessage && dragMessage->what == TAB_DRAG) {
 		switch (transit) {
 			case B_ENTERED_VIEW:
 			case B_INSIDE_VIEW:
@@ -348,6 +341,7 @@ TabContainerView::DoLayout()
 	_ValidateTabVisibility();
 	_SendFakeMouseMoved();
 }
+
 
 void
 TabContainerView::AddTab(const char* label, int32 index)

--- a/src/helpers/tabview/TabManager.cpp
+++ b/src/helpers/tabview/TabManager.cpp
@@ -746,7 +746,7 @@ void WebTabView::_DrawCloseButton(BView* owner, BRect& frame,
 
 	closeRect.InsetBy(closeRect.Width() * 0.30f, closeRect.Height() * 0.30f);
 
-	rgb_color base = ui_color(B_PANEL_BACKGROUND_COLOR);
+	rgb_color base = fColor;
 	float tint = B_LIGHTEN_1_TINT;
 	if (base.Brightness() >= kBrightnessBreakValue) {
 		tint = B_DARKEN_1_TINT *1.2;
@@ -758,7 +758,7 @@ void WebTabView::_DrawCloseButton(BView* owner, BRect& frame,
 		be_control_look->DrawButtonFrame(owner, buttonRect, updateRect,
 			base, base,
 			BControlLook::B_ACTIVATED | BControlLook::B_BLEND_FRAME);
-		rgb_color background = ui_color(B_CONTROL_BACKGROUND_COLOR);
+		rgb_color background = fColor;
 		be_control_look->DrawButtonBackground(owner, buttonRect, updateRect,
 			background, BControlLook::B_ACTIVATED);
 

--- a/src/helpers/tabview/TabManager.cpp
+++ b/src/helpers/tabview/TabManager.cpp
@@ -564,22 +564,7 @@ void
 WebTabView::DrawBackground(BView* owner, BRect frame, const BRect& updateRect,
 		bool isFirst, bool isLast, bool isFront)
 {
-	// Copied from TabView::DrawBackground()
-	rgb_color base = fColor;
-	uint32 borders = BControlLook::B_TOP_BORDER
-		| BControlLook::B_BOTTOM_BORDER;
-
-	if (isFirst)
-		borders |= BControlLook::B_LEFT_BORDER;
-	if (isLast)
-		borders |= BControlLook::B_RIGHT_BORDER;
-	if (isFront) {
-		be_control_look->DrawActiveTab(owner, frame, updateRect, base,
-			0, borders);
-	} else {
-		be_control_look->DrawInactiveTab(owner, frame, updateRect, base,
-			0, borders);
-	}
+	TabView::DrawBackground(owner, frame, updateRect, isFirst, isLast, isFront);
 }
 
 
@@ -622,6 +607,19 @@ WebTabView::DrawContents(BView* owner, BRect frame, const BRect& updateRect,
 		frame.left = frame.left + kIconSize + kIconInset * 2;
 	}
 
+	// Draw colored circle before text
+	BRect circleFrame(frame);
+	circleFrame.OffsetBy(0, 1);
+	circleFrame.right = circleFrame.left + circleFrame.Height();
+	circleFrame.InsetBy(5, 5);
+	const rgb_color highColor = owner->HighColor();
+	owner->SetHighColor(fColor);
+	owner->FillEllipse(circleFrame);
+	owner->SetHighColor(tint_color(fColor, B_DARKEN_1_TINT));
+	owner->StrokeEllipse(circleFrame);
+	frame.left = circleFrame.right + be_control_look->DefaultLabelSpacing();
+
+	owner->SetHighColor(highColor);
 	TabView::DrawContents(owner, frame, updateRect, isFirst, isLast, isFront);
 }
 
@@ -746,7 +744,7 @@ void WebTabView::_DrawCloseButton(BView* owner, BRect& frame,
 
 	closeRect.InsetBy(closeRect.Width() * 0.30f, closeRect.Height() * 0.30f);
 
-	rgb_color base = fColor;
+	rgb_color base = ui_color(B_PANEL_BACKGROUND_COLOR);
 	float tint = B_LIGHTEN_1_TINT;
 	if (base.Brightness() >= kBrightnessBreakValue) {
 		tint = B_DARKEN_1_TINT *1.2;
@@ -758,7 +756,7 @@ void WebTabView::_DrawCloseButton(BView* owner, BRect& frame,
 		be_control_look->DrawButtonFrame(owner, buttonRect, updateRect,
 			base, base,
 			BControlLook::B_ACTIVATED | BControlLook::B_BLEND_FRAME);
-		rgb_color background = fColor;
+		rgb_color background = ui_color(B_PANEL_BACKGROUND_COLOR);
 		be_control_look->DrawButtonBackground(owner, buttonRect, updateRect,
 			background, BControlLook::B_ACTIVATED);
 

--- a/src/helpers/tabview/TabManager.cpp
+++ b/src/helpers/tabview/TabManager.cpp
@@ -705,8 +705,9 @@ WebTabView::SetColor(const rgb_color& color)
 	fColor = nullptr;
 
 	fColor = new rgb_color(color);
-
-	LayoutItem()->InvalidateLayout();
+	if (ContainerView() != nullptr) {
+		ContainerView()->Invalidate();
+	}
 }
 
 

--- a/src/helpers/tabview/TabManager.cpp
+++ b/src/helpers/tabview/TabManager.cpp
@@ -612,14 +612,12 @@ WebTabView::DrawContents(BView* owner, BRect frame, const BRect& updateRect,
 	circleFrame.OffsetBy(0, 1);
 	circleFrame.right = circleFrame.left + circleFrame.Height();
 	circleFrame.InsetBy(5, 5);
-	const rgb_color highColor = owner->HighColor();
 	owner->SetHighColor(fColor);
 	owner->FillEllipse(circleFrame);
 	owner->SetHighColor(tint_color(fColor, B_DARKEN_1_TINT));
 	owner->StrokeEllipse(circleFrame);
 	frame.left = circleFrame.right + be_control_look->DefaultLabelSpacing();
 
-	owner->SetHighColor(highColor);
 	TabView::DrawContents(owner, frame, updateRect, isFirst, isLast, isFront);
 }
 

--- a/src/helpers/tabview/TabManager.h
+++ b/src/helpers/tabview/TabManager.h
@@ -69,6 +69,8 @@ public:
 	const	BString&			TabLabel(int32);
 			void				SetTabIcon(const BView* containedView,
 									const BBitmap* icon);
+			void				SetTabColor(const BView* containedView,
+									const rgb_color& color);
 			void				SetCloseButtonsAvailable(bool available);
 
 	virtual BString				GetToolTipText(int32 index) { return TabLabel(index);}

--- a/src/project/ProjectFolder.cpp
+++ b/src/project/ProjectFolder.cpp
@@ -343,14 +343,7 @@ ProjectFolder::SetGuessedBuilder(const BString& string)
 const rgb_color
 ProjectFolder::Color() const
 {
-	// TODO: Just for testing, should be saved in settings
-	if (fActive) {
-		rgb_color color = {234, 20, 124};
-		return color;
-	} else {
-		rgb_color color = {34, 204, 124};
-		return color;
-	}
+	return (*fSettings)["color"];
 }
 
 
@@ -368,9 +361,9 @@ ProjectFolder::_PrepareSettings()
 			{"value", (int32)BuildMode::DebugMode },
 			{"label", "debug"}}},
 	};
-	rgb_color color = {0, 0, 0};
+	rgb_color color = ui_color(B_PANEL_BACKGROUND_COLOR);
 	fSettings->AddConfig("General", "color",
-		B_TRANSLATE("color:"), color);
+		B_TRANSLATE("Color:"), color);
 
 	fSettings->AddConfig("Build", "build_mode",
 		B_TRANSLATE("Build mode:"), int32(BuildMode::ReleaseMode), &buildModes);

--- a/src/project/ProjectFolder.cpp
+++ b/src/project/ProjectFolder.cpp
@@ -368,8 +368,9 @@ ProjectFolder::_PrepareSettings()
 			{"value", (int32)BuildMode::DebugMode },
 			{"label", "debug"}}},
 	};
+	rgb_color color = {0, 0, 0};
 	fSettings->AddConfig("General", "color",
-		B_TRANSLATE("color:"), 34);
+		B_TRANSLATE("color:"), color);
 
 	fSettings->AddConfig("Build", "build_mode",
 		B_TRANSLATE("Build mode:"), int32(BuildMode::ReleaseMode), &buildModes);

--- a/src/project/ProjectFolder.cpp
+++ b/src/project/ProjectFolder.cpp
@@ -172,16 +172,15 @@ ProjectFolder::LoadSettings()
 	if (fSettings == nullptr)
 		return B_NO_INIT;
 
-	// Try to load old style settings
-	status_t status = _LoadOldSettings();
-	if (status == B_OK) {
-		LogTrace("ProjectFolder: Loaded old style settings");
-		return status;
-	}
-
 	BPath path(Path());
 	path.Append(GenioNames::kProjectSettingsFile);
-	status = fSettings->LoadFromFile(path.Path());
+	status_t status = fSettings->LoadFromFile(path.Path());
+	if (status != B_OK) {
+		// Try to load old style settings
+		status = _LoadOldSettings();
+		if (status == B_OK)
+			LogTrace("ProjectFolder: Loaded old style settings");
+	}
 
 	return status;
 }
@@ -397,6 +396,8 @@ ProjectFolder::_LoadOldSettings()
 	status_t status = oldSettings.GetStatus();
 	if (status != B_OK)
 		return status;
+
+	LogError("OLD STYLE SETTINGS");
 
 	// Load old style settins into new
 	(*fSettings)["build_mode"] = int32(oldSettings.GetInt32("build_mode", BuildMode::ReleaseMode));

--- a/src/project/ProjectFolder.cpp
+++ b/src/project/ProjectFolder.cpp
@@ -340,6 +340,20 @@ ProjectFolder::SetGuessedBuilder(const BString& string)
 }
 
 
+const rgb_color
+ProjectFolder::Color() const
+{
+	// TODO: Just for testing, should be saved in settings
+	if (fActive) {
+		rgb_color color = {234, 20, 124};
+		return color;
+	} else {
+		rgb_color color = {34, 204, 124};
+		return color;
+	}
+}
+
+
 void
 ProjectFolder::_PrepareSettings()
 {
@@ -354,9 +368,12 @@ ProjectFolder::_PrepareSettings()
 			{"value", (int32)BuildMode::DebugMode },
 			{"label", "debug"}}},
 	};
+	fSettings->AddConfig("General", "color",
+		B_TRANSLATE("color:"), 34);
+
 	fSettings->AddConfig("Build", "build_mode",
 		B_TRANSLATE("Build mode:"), int32(BuildMode::ReleaseMode), &buildModes);
-	
+
 	fSettings->AddConfig("Build/Release", "project_release_build_command",
 		B_TRANSLATE("Release build command:"), "");
 	fSettings->AddConfig("Build/Release", "project_release_clean_command",
@@ -373,7 +390,7 @@ ProjectFolder::_PrepareSettings()
 		B_TRANSLATE("Debug execute args:"), "");
 	fSettings->AddConfig("Build/Debug", "project_debug_target",
 		B_TRANSLATE("Debug target:"), "");
-	
+
 	fSettings->AddConfig("Run", "project_run_in_terminal",
 		B_TRANSLATE("Run in terminal"), false);
 }

--- a/src/project/ProjectFolder.h
+++ b/src/project/ProjectFolder.h
@@ -101,6 +101,8 @@ public:
 
 	void						SetGuessedBuilder(const BString& string);
 
+	const rgb_color				Color() const;
+
 	LSPProjectWrapper*			GetLSPServer(const BString& fileType);
 
 

--- a/src/project/ProjectItem.cpp
+++ b/src/project/ProjectItem.cpp
@@ -170,20 +170,6 @@ ProjectItem::DrawItem(BView* owner, BRect bounds, bool complete)
 		// TODO: Don't move it every time
 		fTextControl->MoveTo(textRect.LeftTop());
 	} else {
-		// TODO: Cleanup. We could move this to StyledItem
-		if (isProject) {
-			ProjectFolder *projectFolder = static_cast<ProjectFolder*>(GetSourceItem());
-			const rgb_color oldColor = owner->HighColor();
-			owner->SetHighColor(projectFolder->Color());
-			BRect textRect;
-			textRect.top = bounds.top + 1.5f;
-			textRect.left = iconRect.right + be_control_look->DefaultLabelSpacing() - 3;
-			textRect.bottom = bounds.bottom - 2;
-			textRect.right = textRect.left + owner->StringWidth(Text()) + 5;
-			owner->FillRoundRect(textRect, 9, 10);
-			owner->SetHighColor(oldColor);
-		}
-
 		BPoint textPoint(iconRect.right + be_control_look->DefaultLabelSpacing(),
 						bounds.top + BaselineOffset());
 		// TODO: Apply any style change here (i.e. bold, italic)
@@ -196,6 +182,38 @@ ProjectItem::DrawItem(BView* owner, BRect bounds, bool complete)
 
 		owner->Sync();
 	}
+}
+
+
+/* virtual */
+void
+ProjectItem::DrawText(BView* owner, const char* text, const BPoint& textPoint)
+{
+	BFont font;
+	owner->GetFont(&font);
+	font.SetFace(TextFontFace());
+	owner->SetFont(&font);
+	owner->SetDrawingMode(B_OP_COPY);
+
+	if (GetSourceItem()->Type() == SourceItemType::ProjectFolderItem) {
+		ProjectFolder *projectFolder = static_cast<ProjectFolder*>(GetSourceItem());
+		const rgb_color oldColor = owner->HighColor();
+		owner->SetHighColor(projectFolder->Color());
+
+		// TODO: Fix these calculations.
+		// Better to change DrawText() to also pass a BRect, maybe
+		BRect circleRect;
+		circleRect.top = textPoint.y - BaselineOffset() + 2.5f;
+		circleRect.left = textPoint.x - 3;
+		circleRect.bottom = textPoint.y + 6;
+		circleRect.right = circleRect.left + owner->StringWidth(Text()) + 5;
+		owner->FillRoundRect(circleRect, 9, 10);
+		owner->SetHighColor(oldColor);
+	}
+	owner->MovePenTo(textPoint);
+	owner->DrawString(text);
+
+	owner->Sync();
 }
 
 

--- a/src/project/ProjectItem.cpp
+++ b/src/project/ProjectItem.cpp
@@ -121,7 +121,8 @@ ProjectItem::DrawItem(BView* owner, BRect bounds, bool complete)
 
 	// TODO: until here... (see comment above)
 
-	if (GetSourceItem()->Type() == SourceItemType::ProjectFolderItem) {
+	bool isProject = GetSourceItem()->Type() == SourceItemType::ProjectFolderItem;
+	if (isProject) {
 		ProjectFolder *projectFolder = static_cast<ProjectFolder*>(GetSourceItem());
 		if (projectFolder->Active())
 			SetTextFontFace(B_BOLD_FACE);
@@ -169,6 +170,20 @@ ProjectItem::DrawItem(BView* owner, BRect bounds, bool complete)
 		// TODO: Don't move it every time
 		fTextControl->MoveTo(textRect.LeftTop());
 	} else {
+		// TODO: Cleanup. We could move this to StyledItem
+		if (isProject) {
+			ProjectFolder *projectFolder = static_cast<ProjectFolder*>(GetSourceItem());
+			const rgb_color oldColor = owner->HighColor();
+			owner->SetHighColor(projectFolder->Color());
+			BRect textRect;
+			textRect.top = bounds.top + 1.5f;
+			textRect.left = iconRect.right + be_control_look->DefaultLabelSpacing() - 3;
+			textRect.bottom = bounds.bottom - 2;
+			textRect.right = textRect.left + owner->StringWidth(Text()) + 5;
+			owner->FillRoundRect(textRect, 9, 10);
+			owner->SetHighColor(oldColor);
+		}
+
 		BPoint textPoint(iconRect.right + be_control_look->DefaultLabelSpacing(),
 						bounds.top + BaselineOffset());
 		// TODO: Apply any style change here (i.e. bold, italic)

--- a/src/project/ProjectItem.h
+++ b/src/project/ProjectItem.h
@@ -16,6 +16,7 @@ public:
 					virtual ~ProjectItem();
 
 	virtual void 	DrawItem(BView* owner, BRect bounds, bool complete);
+	virtual void	DrawText(BView* owner, const char* text, const BPoint& textPoint);
 	virtual void 	Update(BView* owner, const BFont* font);
 
 	SourceItem		*GetSourceItem() const { return fSourceItem; };

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -309,8 +309,23 @@ GenioWindow::MessageReceived(BMessage* message)
 			if (code == gCFG.UpdateMessageWhat()) {
 				_HandleConfigurationChanged(message);
 			} else if (code == kMsgProjectSettingsUpdated) {
+				BString key(message->GetString("key", ""));
+				if (key.IsEmpty())
+					break;
 				// Update debug/release
 				_UpdateProjectActivation(fActiveProject != nullptr);
+
+				// TODO: refactor
+				if (key == "color") {
+					for (int32 index = 0; index < fTabManager->CountTabs(); index++) {
+						Editor* editor = fTabManager->EditorAt(index);
+						ProjectFolder* project = editor->GetProjectFolder();
+						if (project != nullptr) {
+							LogError("SET COLOR");
+							fTabManager->SetTabColor(editor, project->Color());
+						}
+					}
+				}
 				// Save project settings
 				fActiveProject->SaveSettings();
 			}
@@ -4088,10 +4103,6 @@ GenioWindow::_HandleConfigurationChanged(BMessage* message)
 	for (int32 index = 0; index < fTabManager->CountTabs(); index++) {
 		Editor* editor = fTabManager->EditorAt(index);
 		editor->ApplySettings();
-		ProjectFolder* project = editor->GetProjectFolder();
-		if (project != nullptr) {
-			fTabManager->SetTabColor(editor, project->Color());
-		}
 	}
 
 	if (key.StartsWith("find_")) {

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -4088,6 +4088,10 @@ GenioWindow::_HandleConfigurationChanged(BMessage* message)
 	for (int32 index = 0; index < fTabManager->CountTabs(); index++) {
 		Editor* editor = fTabManager->EditorAt(index);
 		editor->ApplySettings();
+		ProjectFolder* project = editor->GetProjectFolder();
+		if (project != nullptr) {
+			fTabManager->SetTabColor(editor, project->Color());
+		}
 	}
 
 	if (key.StartsWith("find_")) {

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -1046,8 +1046,13 @@ GenioWindow::MessageReceived(BMessage* message)
 			bool set_caret = message->GetBool("caret_position", false);
 			if (set_caret && index >= 0) {
 				Editor* editor = fTabManager->EditorAt(index);
-				if (editor)
+				if (editor != nullptr) {
 					editor->SetSavedCaretPosition();
+					ProjectFolder* project = editor->GetProjectFolder();
+					if (project != nullptr) {
+						fTabManager->SetTabColor(editor, project->Color());
+					}
+				}
 			}
 			break;
 		}

--- a/src/ui/StyledItem.cpp
+++ b/src/ui/StyledItem.cpp
@@ -99,6 +99,13 @@ StyledItem::SetTextFontFace(uint16 fontFace)
 }
 
 
+uint16
+StyledItem::TextFontFace() const
+{
+	return fFontFace;
+}
+
+
 void
 StyledItem::SetExtraText(const char* extraText)
 {
@@ -133,7 +140,7 @@ StyledItem::GetToolTipText() const
 	return fToolTipText.String();
 }
 
-	
+
 /* virtual */
 void
 StyledItem::DrawText(BView* owner, const char* text, const BPoint& point)

--- a/src/ui/StyledItem.h
+++ b/src/ui/StyledItem.h
@@ -22,6 +22,7 @@ public:
 
 	// TODO: Maybe SetFont ?
 	void			SetTextFontFace(uint16 fontFace);
+	uint16			TextFontFace() const;
 
 	void			SetExtraText(const char* extraText);
 	const char*		ExtraText() const;


### PR DESCRIPTION
Implement custom colored tabs: the user can configure a custom color for every project, which will be showed in the editor tabs relative to that project.
Color is saved into project settings.

Also fixed loading project settings: now Genio will try loading new style settigs first, and only fallback to old style if this didn't work.

Also added  rgb_color/BColorControl support to Settings / ConfigWindow

fixes #184 

