### PR TITLE
Moved getting branch from ProjectItem to ProjectFolderBrowser

### DIFF
--- a/src/git/SourceControlPanel.cpp
+++ b/src/git/SourceControlPanel.cpp
@@ -672,12 +672,14 @@ SourceControlPanel::_UpdateRepositoryView()
 void
 SourceControlPanel::_SwitchBranch(BMessage *message)
 {
+	LogInfo("_SwitchBranch()");
 	ProjectFolder* project = _GetSelectedProject();
 	if (project->IsBuilding()) {
 		OKAlert("Source control panel",
 			B_TRANSLATE("The project is building, changing branch not allowed."),
 			B_STOP_ALERT);
 	} else {
+		LogInfo("_SwitchBranch(): on");
 		const BString branch = message->GetString("value");
 		const BString sender = message->GetString("sender");
 

--- a/src/git/SourceControlPanel.cpp
+++ b/src/git/SourceControlPanel.cpp
@@ -30,6 +30,7 @@
 #include "GTextAlert.h"
 #include "Log.h"
 #include "ProjectFolder.h"
+#include "ProjectItem.h"
 #include "ProjectsFolderBrowser.h"
 #include "RepositoryView.h"
 #include "StringFormatter.h"
@@ -683,6 +684,25 @@ SourceControlPanel::_SwitchBranch(BMessage *message)
 		auto repo = project->GetRepository();
 		repo->SwitchBranch(branch);
 		fCurrentBranch = repo->GetCurrentBranch();
+		BString branchName = project->GetRepository()->GetCurrentBranch();
+		BString extraText;
+		extraText << "  [" << branchName << "]";
+		GenioWindow* window = dynamic_cast<GenioWindow*>(Window());
+		if (window != nullptr) {
+			ProjectsFolderBrowser* browser = window->GetProjectBrowser();
+			if (browser != nullptr) {
+				ProjectItem* item = browser->GetProjectItemForProject(project);
+				if (item != nullptr) {
+					item->SetExtraText(extraText);
+					BString toolTipText;
+					toolTipText.SetToFormat("%s: %s\n%s: %s\n%s: %s",
+						B_TRANSLATE("Project"), project->Name().String(),
+						B_TRANSLATE("Path"), project->Path().String(),
+						B_TRANSLATE("Current branch"), branchName.String());
+					item->SetToolTipText(toolTipText);
+				}
+			}
+		}
 
 		if (sender == kSenderBranchOptionList) {
 			// we update the repository view

--- a/src/project/ProjectItem.cpp
+++ b/src/project/ProjectItem.cpp
@@ -16,7 +16,6 @@
 #include <Window.h>
 
 #include "IconCache.h"
-#include "GitRepository.h"
 #include "ProjectFolder.h"
 
 #undef B_TRANSLATION_CONTEXT

--- a/src/project/ProjectItem.cpp
+++ b/src/project/ProjectItem.cpp
@@ -127,30 +127,8 @@ ProjectItem::DrawItem(BView* owner, BRect bounds, bool complete)
 		if (projectFolder->Active())
 			SetTextFontFace(B_BOLD_FACE);
 		else
+
 			SetTextFontFace(B_REGULAR_FACE);
-
-		// TODO: this part is quite computationally intensive
-		// and shoud be moved away from the DrawItem.
-
-		BString projectName = Text();
-		BString projectPath = projectFolder->Path();
-		BString branchName;
-		try {
-			if (projectFolder->GetRepository()) {
-				branchName = projectFolder->GetRepository()->GetCurrentBranch();
-				BString extraText;
-				extraText << "  [" << branchName << "]";
-				SetExtraText(extraText);
-			}
-		} catch (const Genio::Git::GitException &ex) {
-		}
-
-		BString toolTipText;
-		toolTipText.SetToFormat("%s: %s\n%s: %s\n%s: %s",
-									B_TRANSLATE("Project"), projectName.String(),
-									B_TRANSLATE("Path"), projectPath.String(),
-									B_TRANSLATE("Current branch"), branchName.String());
-		SetToolTipText(toolTipText);
 	} else if (fOpenedInEditor)
 		SetTextFontFace(B_ITALIC_FACE);
 	else

--- a/src/project/ProjectItem.h
+++ b/src/project/ProjectItem.h
@@ -8,6 +8,7 @@
 #include "StyledItem.h"
 
 
+
 class BTextControl;
 class SourceItem;
 class ProjectItem : public StyledItem {

--- a/src/ui/ProjectsFolderBrowser.cpp
+++ b/src/ui/ProjectsFolderBrowser.cpp
@@ -42,8 +42,6 @@ ProjectsFolderBrowser::ProjectsFolderBrowser()
 	fGenioWatchingFilter = new GenioWatchingFilter();
 	SetInvocationMessage(new BMessage(MSG_PROJECT_MENU_OPEN_FILE));
 	BPrivate::BPathMonitor::SetWatchingInterface(fGenioWatchingFilter);
-
-	SetFlags(Flags() | B_PULSE_NEEDED);
 }
 
 
@@ -373,37 +371,6 @@ ProjectsFolderBrowser::MessageReceived(BMessage* message)
 		default:
 			BOutlineListView::MessageReceived(message);
 			break;
-	}
-}
-
-
-/* virtual */
-void
-ProjectsFolderBrowser::Pulse()
-{
-	// TODO: We could do this also with a BMessageRunner
-	for (int32 i = 0; i < CountProjects(); i++) {
-		ProjectFolder* project = ProjectAt(i);
-		BString projectName = project->Name();
-		BString projectPath = project->Path();
-		BString branchName;
-		ProjectItem* projectItem = GetProjectItemForProject(project);
-		try {
-			if (project->GetRepository()) {
-				branchName = project->GetRepository()->GetCurrentBranch();
-				BString extraText;
-				extraText << "  [" << branchName << "]";
-				projectItem->SetExtraText(extraText);
-			}
-		} catch (const Genio::Git::GitException &ex) {
-		}
-
-		BString toolTipText;
-		toolTipText.SetToFormat("%s: %s\n%s: %s\n%s: %s",
-								B_TRANSLATE("Project"), projectName.String(),
-								B_TRANSLATE("Path"), projectPath.String(),
-								B_TRANSLATE("Current branch"), branchName.String());
-		projectItem->SetToolTipText(toolTipText);
 	}
 }
 

--- a/src/ui/ProjectsFolderBrowser.h
+++ b/src/ui/ProjectsFolderBrowser.h
@@ -37,7 +37,6 @@ public:
 	virtual void	AttachedToWindow();
 	virtual void	DetachedFromWindow();
 	virtual void	MessageReceived(BMessage* message);
-	virtual void	Pulse();
 
 	ProjectItem*	GetSelectedProjectItem() const;
 	ProjectItem*	GetProjectItemForProject(ProjectFolder*);

--- a/src/ui/ProjectsFolderBrowser.h
+++ b/src/ui/ProjectsFolderBrowser.h
@@ -26,7 +26,6 @@ enum {
 class ProjectFolder;
 class ProjectItem;
 class GenioWatchingFilter;
-
 class ProjectsFolderBrowser : public BOutlineListView {
 public:
 					 ProjectsFolderBrowser();
@@ -38,6 +37,7 @@ public:
 	virtual void	AttachedToWindow();
 	virtual void	DetachedFromWindow();
 	virtual void	MessageReceived(BMessage* message);
+	virtual void	Pulse();
 
 	ProjectItem*	GetSelectedProjectItem() const;
 	ProjectItem*	GetProjectItemForProject(ProjectFolder*);


### PR DESCRIPTION
We were retrieving the current branch at every DrawItem call.
Moreover, the code was very complex.

Moved that code into ProjectFolderBrowser::Pulse() for now.
We could use a BMessageRunner instead so we can define better granularity (e.g. 3 seconds).