### PR TITLE
ConsoleIOThread: rename/cleanup

### DIFF
--- a/src/helpers/GrepThread.cpp
+++ b/src/helpers/GrepThread.cpp
@@ -50,8 +50,9 @@ GrepThread::OnStdOutputLine(const BString& stdOut)
 	}
 }
 
+
 void
-GrepThread::OnThreadShutdown()
+GrepThread::ThreadExitNotification()
 {
 	if (fCurrentMessage.HasMessage("line"))
 		fTarget.SendMessage(&fCurrentMessage);

--- a/src/helpers/GrepThread.h
+++ b/src/helpers/GrepThread.h
@@ -2,9 +2,7 @@
  * Copyright 2023, Andrea Anzani <andrea.anzani@gmail.com>
  * All rights reserved. Distributed under the terms of the MIT license.
  */
-#ifndef GrepThread_H
-#define GrepThread_H
-
+#pragma once
 
 #include "ConsoleIOThread.h"
 
@@ -20,9 +18,9 @@ public:
 	GrepThread(BMessage* cmd_message, const BMessenger& consoleTarget);
 
 protected:
-	virtual	void	OnStdOutputLine(const BString& stdOut);
-	virtual void	OnStdErrorLine(const BString& stdErr) {};
-	virtual void	OnThreadShutdown();
+	virtual	void	OnStdOutputLine(const BString& stdOut) override;
+	virtual void	OnStdErrorLine(const BString& stdErr) override {};
+	virtual void	ThreadExitNotification() override;
 private:
 	char fCurrentFileName[B_PATH_NAME_LENGTH];
 	char fLine[MAX_LINE_LEN];
@@ -30,6 +28,3 @@ private:
 	BMessage fCurrentMessage;
 	entry_ref fCurrentRef;
 };
-
-
-#endif // GrepThread_H

--- a/src/helpers/console_io/ConsoleIOThread.h
+++ b/src/helpers/console_io/ConsoleIOThread.h
@@ -26,13 +26,15 @@
 #ifndef CONSOLE_THREAD_H
 #define CONSOLE_THREAD_H
 
+#include "GenericThread.h"
+
+#include <Locker.h>
 #include <Message.h>
 #include <Messenger.h>
 #include <String.h>
 
-#include "GenericThread.h"
-#include <stdio.h>
-#include <Locker.h>
+#include <cstdio>
+
 #include "PipeImage.h"
 
 enum {
@@ -46,16 +48,16 @@ public:
 								ConsoleIOThread(BMessage* cmd_message,
 									const BMessenger& consoleTarget);
 
-								~ConsoleIOThread();
+	virtual						~ConsoleIOThread();
 
 			status_t			InterruptExternal();
 
-			bool				IsDone() { return fIsDone; };
+			bool				IsDone() const { return fIsDone; };
 
 protected:
 	virtual	void	OnStdOutputLine(const BString& stdOut);
 	virtual void	OnStdErrorLine(const BString& stdErr);
-	virtual void	OnThreadShutdown();
+	virtual void	ThreadExitNotification();
 	BMessenger		fTarget;
 
 private:
@@ -63,15 +65,13 @@ private:
 			bool				IsProcessAlive();
 			status_t			GetFromPipe(BString& stdOut, BString& stdErr);
 			void				ClosePipes();
-	virtual	status_t			ExecuteUnit();
-	virtual	status_t			ThreadShutdown();
+	virtual	status_t			ExecuteUnit() override;
+	virtual	status_t			ThreadShutdown() override;
 
 			void				_CleanPipes();
 			status_t			_RunExternalProcess();
 
 			status_t			Kill(void);
-
-
 
 			thread_id			fProcessId;
 			FILE*				fConsoleOutput;


### PR DESCRIPTION
Try to clarify (for myself, mostly) how things work: Added override to overridden virtual methods.
Renamed OnThreadShutdown to ThreadExitNotification, to keep consistency with other class hooks (ThreadShutdown, etc). I didn't rename the other hooks yet.
Style fixes

No functional change intended

Cleanups