### PR TITLE
Problems tab: Resizable columns

### DIFF
--- a/src/ui/ProblemsPanel.cpp
+++ b/src/ui/ProblemsPanel.cpp
@@ -44,11 +44,11 @@ ProblemsPanel::ProblemsPanel(BTabView* tabView): BColumnListView(ProblemLabel,
 
 {
 	AddColumn(new BStringColumn( B_TRANSLATE("Category"),
-								200.0, 200.0, 200.0, 0), kCategoryColumn);
+								200.0, 20.0, 800.0, 0), kCategoryColumn);
 	AddColumn(new BStringColumn( B_TRANSLATE("Message"),
-								600.0, 600.0, 800.0, 0), kMessageColumn);
+								600.0, 20.0, 2000.0, 0), kMessageColumn);
 	AddColumn(new BStringColumn( B_TRANSLATE("Source"),
-								200.0, 200.0, 200.0, 0), kSourceColumn);
+								100.0, 20.0, 200.0, 0), kSourceColumn);
 
 	fPopUpMenu = new BPopUpMenu("_popup");
 	fPopUpMenu->AddItem(fQuickFixItem = new BMenuItem("fix", nullptr));


### PR DESCRIPTION
With 2000px, the max. width of the "Message" column might be wider than necessary, but better than being too narrow for an exceptionally long message. I trust there arean't longer messages...