### PR TITLE
Fix/open child and parent folder

### DIFF
--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -3528,16 +3528,18 @@ GenioWindow::_ProjectFolderOpen(const entry_ref& ref, bool activate)
 	if (status != B_OK)
 		return status;
 
+	BString newProjectPathString = newProjectPath.Path();
+	newProjectPathString.Append("/");
 	for (int32 index = 0; index < GetProjectBrowser()->CountProjects(); index++) {
 		ProjectFolder* pProject = GetProjectBrowser()->ProjectAt(index);
 		BString existingProjectPath = pProject->Path();
 		existingProjectPath.Append("/");
 		// Check if it's a subfolder of an existing open project
 		// TODO: Ideally, this wouldn't be a problem: it should be perfectly possibile
-		if (BString(newProjectPath.Path()).StartsWith(existingProjectPath))
+		if (newProjectPathString.StartsWith(existingProjectPath))
 			return B_ERROR;
 		// check if it's a parent of an existing project
-		if (existingProjectPath.StartsWith(newProjectPath.Path()))
+		if (existingProjectPath.StartsWith(newProjectPathString))
 			return B_ERROR;
 		// Check if already open
 		if (*pProject->EntryRef() == ref)

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -3524,16 +3524,25 @@ GenioWindow::_ProjectFolderOpen(const entry_ref& ref, bool activate)
 	if (BDirectory(&dirEntry).IsRootDirectory())
 		return B_ERROR;
 
-	// Check if already open
+	BPath newProjectPath;
+	status_t status = dirEntry.GetPath(&newProjectPath);
+	if (status != B_OK)
+		return status;
 	for (int32 index = 0; index < GetProjectBrowser()->CountProjects(); index++) {
 		ProjectFolder* pProject = GetProjectBrowser()->ProjectAt(index);
+		const BString existingProjectPath = pProject->Path();
+		// Check if it's a subfolder of an existing open project
+		// TODO: Ideally, this wouldn't be a problem: it should be perfectly possibile
+		if (BString(newProjectPath.Path()).StartsWith(existingProjectPath))
+			return B_ERROR;
+		// Check if already open
 		if (*pProject->EntryRef() == ref)
 			return B_OK;
 	}
 
 	BMessenger msgr(this);
 	ProjectFolder* newProject = new ProjectFolder(ref, msgr);
-	status_t status = newProject->Open();
+	status = newProject->Open();
 	if (status != B_OK) {
 		BString notification;
 		notification << "Project open fail: " << newProject->Name();

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -3532,6 +3532,10 @@ GenioWindow::_ProjectFolderOpen(const entry_ref& ref, bool activate)
 	newProjectPathString.Append("/");
 	for (int32 index = 0; index < GetProjectBrowser()->CountProjects(); index++) {
 		ProjectFolder* pProject = GetProjectBrowser()->ProjectAt(index);
+		// Check if already open
+		if (*pProject->EntryRef() == ref)
+			return B_OK;
+
 		BString existingProjectPath = pProject->Path();
 		existingProjectPath.Append("/");
 		// Check if it's a subfolder of an existing open project
@@ -3541,9 +3545,6 @@ GenioWindow::_ProjectFolderOpen(const entry_ref& ref, bool activate)
 		// check if it's a parent of an existing project
 		if (existingProjectPath.StartsWith(newProjectPathString))
 			return B_ERROR;
-		// Check if already open
-		if (*pProject->EntryRef() == ref)
-			return B_OK;
 	}
 
 	BMessenger msgr(this);

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -3527,9 +3527,11 @@ GenioWindow::_ProjectFolderOpen(const entry_ref& ref, bool activate)
 	status_t status = dirEntry.GetPath(&newProjectPath);
 	if (status != B_OK)
 		return status;
+
 	for (int32 index = 0; index < GetProjectBrowser()->CountProjects(); index++) {
 		ProjectFolder* pProject = GetProjectBrowser()->ProjectAt(index);
-		const BString existingProjectPath = pProject->Path();
+		BString existingProjectPath = pProject->Path();
+		existingProjectPath.Append("/");
 		// Check if it's a subfolder of an existing open project
 		// TODO: Ideally, this wouldn't be a problem: it should be perfectly possibile
 		if (BString(newProjectPath.Path()).StartsWith(existingProjectPath))

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -819,7 +819,7 @@ GenioWindow::MessageReceived(BMessage* message)
 			}
 			break;
 		}
-				case MSG_CREATE_NEW_PROJECT:
+		case MSG_CREATE_NEW_PROJECT:
 		{
 			entry_ref templateRef;
 			if (message->FindRef("template_ref", &templateRef) != B_OK) {
@@ -3496,11 +3496,10 @@ GenioWindow::_ProjectFolderOpen(BMessage *message)
 {
 	entry_ref ref;
 	status_t status = message->FindRef("refs", &ref);
-	if (status == B_OK) {
+	if (status == B_OK)
 		status = _ProjectFolderOpen(ref);
-	} else {
+	if (status != B_OK)
 		OKAlert("Open project folder", B_TRANSLATE("Invalid project folder"), B_STOP_ALERT);
-	}
 
 	return status;
 }

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -3534,6 +3534,9 @@ GenioWindow::_ProjectFolderOpen(const entry_ref& ref, bool activate)
 		// TODO: Ideally, this wouldn't be a problem: it should be perfectly possibile
 		if (BString(newProjectPath.Path()).StartsWith(existingProjectPath))
 			return B_ERROR;
+		// check if it's a parent of an existing project
+		if (existingProjectPath.StartsWith(newProjectPath.Path()))
+			return B_ERROR;
 		// Check if already open
 		if (*pProject->EntryRef() == ref)
 			return B_OK;

--- a/src/ui/GenioWindow.h
+++ b/src/ui/GenioWindow.h
@@ -123,6 +123,7 @@ private:
 			status_t			_ProjectFolderOpen(BMessage *message);
 			status_t			_ProjectFolderOpen(const entry_ref& ref, bool activate = false);
 			void				_ProjectFolderActivate(ProjectFolder* project);
+			void				_TryAssociateOrphanedEditorsWithProject(ProjectFolder* project);
 
 			status_t			_ShowSelectedItemInTracker();
 			status_t			_ShowInTracker(const entry_ref& ref, const node_ref* nref = NULL);


### PR DESCRIPTION
Avoid opening a child or parent folder of a currently opened project.
Also show an alert if _ProjectFolderOpen() returns an error.