### PR TITLE
RepositoryView improvements

### DIFF
--- a/src/git/RepositoryView.cpp
+++ b/src/git/RepositoryView.cpp
@@ -241,10 +241,10 @@ RepositoryView::_BuildBranchTree(const BString &branch, BListItem *rootItem, uin
 {
 	// Do not show an outline
 	if (!gCFG["repository_outline"]) {
-		StyledItem* item = new BranchItem(branch.String(), branch.String(), branchType);
+		StyledItem* item = new BranchItem(branch.String(), branch.String(), branchType, 1);
 		if (checker(branch))
 			item->SetTextFontFace(B_UNDERSCORE_FACE);
-		AddUnder(item, rootItem);
+		AddItem(item);
 		return;
 	}
 

--- a/src/git/RepositoryView.cpp
+++ b/src/git/RepositoryView.cpp
@@ -275,7 +275,7 @@ RepositoryView::FindItem(const BString& name, T* startItem, bool oneLevelOnly, u
 	for (int32 i = startIndex; i< countItems; i++) {
 		T *item = dynamic_cast<T*>(ItemUnderAt(startItem, oneLevelOnly, i));
 		if (item != nullptr &&
-			name.ICompare(item->Text()) == 0 &&
+			name == item->Text() &&
 			item->OutlineLevel() == outlinelevel) {
 			return item;
 		}

--- a/src/git/RepositoryView.cpp
+++ b/src/git/RepositoryView.cpp
@@ -245,7 +245,7 @@ RepositoryView::_BuildBranchTree(const BString &branch, BranchItem *rootItem, ui
 		uint32 lastIndex = parts.size();
 
 		BString partName = parts.at(i).c_str();
-		auto partItem = FindItem<BranchItem>(partName, rootItem, false, i+1);
+		auto partItem = FindItem<BranchItem>(partName, parentitem, false, i+1);
 		if (partItem != nullptr) {
 			parentitem = partItem;
 		} else {

--- a/src/git/RepositoryView.cpp
+++ b/src/git/RepositoryView.cpp
@@ -225,7 +225,7 @@ RepositoryView::UpdateRepository(ProjectFolder *selectedProject, const BString &
 
 
 void
-RepositoryView::_BuildBranchTree(const BString &branch, BranchItem *rootItem, uint32 branchType,
+RepositoryView::_BuildBranchTree(const BString &branch, BListItem *rootItem, uint32 branchType,
 									const auto& checker)
 {
 	// Do not show an outline
@@ -238,14 +238,14 @@ RepositoryView::_BuildBranchTree(const BString &branch, BranchItem *rootItem, ui
 	}
 
 	// show the outline
-	BranchItem *parentitem = rootItem;
+	BListItem *parentitem = rootItem;
 	std::filesystem::path path = branch.String();
 	std::vector<std::string> parts(path.begin(), path.end());
 	for (uint32 i = 0; i < parts.size(); i++) {
 		uint32 lastIndex = parts.size();
 
 		BString partName = parts.at(i).c_str();
-		auto partItem = FindItem<BranchItem>(partName, parentitem, false, i+1);
+		auto partItem = FindItem(partName, parentitem);
 		if (partItem != nullptr) {
 			parentitem = partItem;
 		} else {
@@ -265,18 +265,17 @@ RepositoryView::_BuildBranchTree(const BString &branch, BranchItem *rootItem, ui
 }
 
 
-template <typename T>
-T*
-RepositoryView::FindItem(const BString& name, T* startItem, bool oneLevelOnly, uint32 outlinelevel)
+BListItem*
+RepositoryView::FindItem(const BString& name, BListItem* startItem)
 {
 	const int32 countItems = FullListCountItems();
 	const int32 startIndex = 0;
 
 	for (int32 i = startIndex; i< countItems; i++) {
-		T *item = dynamic_cast<T*>(ItemUnderAt(startItem, oneLevelOnly, i));
-		if (item != nullptr &&
-			name == item->Text() &&
-			item->OutlineLevel() == outlinelevel) {
+		BStringItem* item = dynamic_cast<BStringItem*>(ItemUnderAt(startItem, true, i));
+		if (item == nullptr)
+			return nullptr;
+		if (name == item->Text()) {
 			return item;
 		}
 	}

--- a/src/git/RepositoryView.cpp
+++ b/src/git/RepositoryView.cpp
@@ -254,7 +254,7 @@ RepositoryView::_BuildBranchTree(const BString &branch, BListItem *rootItem, uin
 	std::vector<std::string> parts(path.begin(), path.end());
 	uint32 lastIndex = parts.size() - 1;
 	uint32 i = 0;
-	while (i <= lastIndex) {
+	while (i < lastIndex) {
 		BString partName = parts.at(i).c_str();
 		auto partItem = EachItemUnder(
 			parentitem, true, PartFinder, const_cast<BString*>(&partName));
@@ -274,13 +274,11 @@ RepositoryView::_BuildBranchTree(const BString &branch, BListItem *rootItem, uin
 		i++;
 	}
 
-	if (i == lastIndex) {
-		BString partName = parts.at(i).c_str();
-		auto newItem = new BranchItem(branch.String(), partName, branchType, i);
-		if (checker(branch))
-			newItem->SetTextFontFace(B_UNDERSCORE_FACE);
-		AddUnder(newItem, parentitem);
-	}
+	BString partName = parts.at(i).c_str();
+	auto newItem = new BranchItem(branch.String(), partName, branchType, i);
+	if (checker(branch))
+		newItem->SetTextFontFace(B_UNDERSCORE_FACE);
+	AddUnder(newItem, parentitem);
 }
 
 

--- a/src/git/RepositoryView.cpp
+++ b/src/git/RepositoryView.cpp
@@ -252,27 +252,34 @@ RepositoryView::_BuildBranchTree(const BString &branch, BListItem *rootItem, uin
 	BListItem *parentitem = rootItem;
 	std::filesystem::path path = branch.String();
 	std::vector<std::string> parts(path.begin(), path.end());
-	for (uint32 i = 0; i < parts.size(); i++) {
-		uint32 lastIndex = parts.size();
-
+	uint32 lastIndex = parts.size() - 1;
+	uint32 i = 0;
+	while (i <= lastIndex) {
 		BString partName = parts.at(i).c_str();
 		auto partItem = EachItemUnder(
 			parentitem, true, PartFinder, const_cast<BString*>(&partName));
 		if (partItem != nullptr) {
 			parentitem = partItem;
 		} else {
-			if (i == (lastIndex-1)) {
-				auto newItem = new BranchItem(branch.String(), partName, branchType, i);
-				if (checker(branch))
-					newItem->SetTextFontFace(B_UNDERSCORE_FACE);
-				AddUnder(newItem, parentitem);
-				parentitem = rootItem;
-			} else {
-				auto newItem = new BranchItem(branch.String(), partName, kHeader, i);
-				if (AddUnder(newItem, parentitem))
-					parentitem = newItem;
-			}
+			break;
 		}
+		i++;
+	}
+
+	while (i < lastIndex) {
+		BString partName = parts.at(i).c_str();
+		auto newItem = new BranchItem(branch.String(), partName, kHeader, i);
+		if (AddUnder(newItem, parentitem))
+			parentitem = newItem;
+		i++;
+	}
+
+	if (i == lastIndex) {
+		BString partName = parts.at(i).c_str();
+		auto newItem = new BranchItem(branch.String(), partName, branchType, i);
+		if (checker(branch))
+			newItem->SetTextFontFace(B_UNDERSCORE_FACE);
+		AddUnder(newItem, parentitem);
 	}
 }
 

--- a/src/git/RepositoryView.cpp
+++ b/src/git/RepositoryView.cpp
@@ -271,16 +271,12 @@ RepositoryView::FindItem(const BString& name, T* startItem, bool oneLevelOnly, u
 {
 	const int32 countItems = FullListCountItems();
 	const int32 startIndex = 0;
-	// LogInfo("FindItem: item '%s' under '%s' with countItems = %d, startIndex = %d",
-		// name.String(), startItem->Text(), countItems, startIndex);
+
 	for (int32 i = startIndex; i< countItems; i++) {
-		// LogInfo("FindItem: for i = %d to %d", i, countItems);
 		T *item = dynamic_cast<T*>(ItemUnderAt(startItem, oneLevelOnly, i));
-		// LogInfo("FindItem: current item '%s' at %d", item->Text(), i);
 		if (item != nullptr &&
 			name.ICompare(item->Text()) == 0 &&
 			item->OutlineLevel() == outlinelevel) {
-			// LogInfo("FindItem: *** found item '%s' at level", item->Text(), item->OutlineLevel());
 			return item;
 		}
 	}

--- a/src/git/RepositoryView.cpp
+++ b/src/git/RepositoryView.cpp
@@ -25,6 +25,17 @@
 #define B_TRANSLATION_CONTEXT "SourceControlPanel"
 
 
+// Checker for EachItemUnder
+static
+BListItem*
+PartFinder(BListItem* item, void* name)
+{
+	if (*(BString*)name == ((BStringItem*)item)->Text())
+		return item;
+	return nullptr;
+}
+
+
 RepositoryView::RepositoryView()
 	:
 	BOutlineListView("RepositoryView", B_SINGLE_SELECTION_LIST),
@@ -245,7 +256,8 @@ RepositoryView::_BuildBranchTree(const BString &branch, BListItem *rootItem, uin
 		uint32 lastIndex = parts.size();
 
 		BString partName = parts.at(i).c_str();
-		auto partItem = FindItem(partName, parentitem);
+		auto partItem = EachItemUnder(
+			parentitem, true, PartFinder, const_cast<BString*>(&partName));
 		if (partItem != nullptr) {
 			parentitem = partItem;
 		} else {
@@ -262,25 +274,6 @@ RepositoryView::_BuildBranchTree(const BString &branch, BListItem *rootItem, uin
 			}
 		}
 	}
-}
-
-
-BListItem*
-RepositoryView::FindItem(const BString& name, BListItem* startItem)
-{
-	const int32 countItems = FullListCountItems();
-	const int32 startIndex = 0;
-
-	for (int32 i = startIndex; i< countItems; i++) {
-		BStringItem* item = dynamic_cast<BStringItem*>(ItemUnderAt(startItem, true, i));
-		if (item == nullptr)
-			return nullptr;
-		if (name == item->Text()) {
-			return item;
-		}
-	}
-
-	return nullptr;
 }
 
 

--- a/src/git/RepositoryView.h
+++ b/src/git/RepositoryView.h
@@ -46,8 +46,6 @@ private:
 	void			_BuildBranchTree(const BString &branch, BListItem *rootItem,
 						uint32 branchType, const auto& checker);
 
-	BListItem*		FindItem(const BString& name, BListItem* startItem);
-
 	void			_ShowPopupMenu(BPoint where);
 
 	BString			fCurrentBranch;

--- a/src/git/RepositoryView.h
+++ b/src/git/RepositoryView.h
@@ -43,8 +43,7 @@ public:
 private:
 
 	BranchItem*		_InitEmptySuperItem(const BString &label);
-	void			_BuildBranchTree(const BString &branch, BListItem *rootItem,
-						uint32 branchType, const auto& checker);
+	void			_BuildBranchTree(const BString &branch, uint32 branchType, const auto& checker);
 
 	void			_ShowPopupMenu(BPoint where);
 

--- a/src/git/RepositoryView.h
+++ b/src/git/RepositoryView.h
@@ -43,12 +43,10 @@ public:
 private:
 
 	BranchItem*		_InitEmptySuperItem(const BString &label);
-	void			_BuildBranchTree(const BString &branch, BranchItem *rootItem,
+	void			_BuildBranchTree(const BString &branch, BListItem *rootItem,
 						uint32 branchType, const auto& checker);
 
-	template <typename T>
-	T* 				FindItem(const BString& name, T* startItem, bool oneLevelOnly,
-						uint32 outlinelevel);
+	BListItem*		FindItem(const BString& name, BListItem* startItem);
 
 	void			_ShowPopupMenu(BPoint where);
 


### PR DESCRIPTION
Some fixes and performance improvements.

For a typical repo with just a few branches the performance improvements are in fact negative, but we are talking about sub millisecond total time there. In my not very old desktop I need about 50 branches to get a clear positive impact, and we are still in the millisecond area.

On the other hand, we all know of that little project with more than 55 thousand tags. Populating the view without the changes takes my desktop 33 seconds without the outline option. With the outline option... well, after 3 hours it still has only 24250 items, and is inserting them at the speed of 0,75 items **per second**. After the changes it takes 28 seconds, whatever the setting.