### PR TITLE
ConfigManager: do not throw on invalid key

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -305,11 +305,8 @@ ConfigManager::_CheckKeyIsValid(const char* key) const
 {
 	type_code type;
 	if (fStorage.GetInfo(key, &type) != B_OK) {
-		BString detail("No config key: ");
-		detail << key;
-		debugger(detail.String());
-		LogFatal(detail.String());
-		throw new std::exception();
+		LogError("No config key: %s", key);
+		return false;
 	}
 	return true;
 }


### PR DESCRIPTION
Fixes Genio crashing when the project settings window is closed with the focus in one of the color text fields.