### PR TITLE
Cleanup/templatesmenu

### DIFF
--- a/src/templates/TemplatesMenu.cpp
+++ b/src/templates/TemplatesMenu.cpp
@@ -99,12 +99,14 @@ TemplatesMenu::SetViewMode(ViewMode mode, bool enableNewFolder)
 
 
 void
-TemplatesMenu::SetSenderEntryRef(const entry_ref* ref)
+TemplatesMenu::SetSender(const void* sender, const entry_ref* ref)
 {
 	BEntry entry(ref);
 	BPath path;
 	path.SetTo(&entry);
 
+	fMessage->RemoveName("sender");
+	fMessage->AddPointer("sender", sender);
 	fMessage->RemoveName("sender_ref");
 	fMessage->AddRef("sender_ref", ref);
 }
@@ -147,10 +149,13 @@ TemplatesMenu::_BuildMenu()
 		// Always create a new message
 		// TODO: Why ?
 
+		void* sender = nullptr;
+		fMessage->FindPointer("sender", &sender);
 		entry_ref senderRef;
 		fMessage->FindRef("sender_ref", &senderRef);
 		BMessage *message = new BMessage(fMessage->what);
 		message->AddString("type","new_folder");
+		message->AddPointer("sender", sender);
 		message->AddRef("sender_ref", &senderRef);
 
 		// add the folder
@@ -227,10 +232,13 @@ TemplatesMenu::_BuildTemplateItems(const BString& directory)
 				entry_ref ref;
 				entry.GetRef(&ref);
 
+				void* sender = nullptr;
+				fMessage->FindPointer("sender", &sender);
 				entry_ref senderRef;
 				fMessage->FindRef("sender_ref", &senderRef);
 				BMessage *message = new BMessage(fMessage->what);
 				message->AddRef("refs", &ref);
+				message->AddPointer("sender", sender);
 				message->AddRef("sender_ref", &senderRef);
 				if (entry.IsDirectory())
 					message->AddString("type","new_folder_template");

--- a/src/templates/TemplatesMenu.cpp
+++ b/src/templates/TemplatesMenu.cpp
@@ -29,6 +29,7 @@
 
 #include "IconMenuItem.h"
 
+
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "TemplatesMenu"
 
@@ -96,6 +97,19 @@ TemplatesMenu::SetViewMode(ViewMode mode, bool enableNewFolder)
 	fEnableNewFolder = enableNewFolder;
 }
 
+
+void
+TemplatesMenu::SetSenderEntryRef(const entry_ref* ref)
+{
+	BEntry entry(ref);
+	BPath path;
+	path.SetTo(&entry);
+
+	fMessage->RemoveName("sender_ref");
+	fMessage->AddRef("sender_ref", ref);
+}
+
+
 // BMessages are passed in the constructor for each of the events:
 // * Create new item
 // * Show user template folder
@@ -131,8 +145,14 @@ TemplatesMenu::_BuildMenu()
 
 	if (fShowNewFolder) {
 		// Always create a new message
+		// TODO: Why ?
+
+		entry_ref senderRef;
+		fMessage->FindRef("sender_ref", &senderRef);
 		BMessage *message = new BMessage(fMessage->what);
 		message->AddString("type","new_folder");
+		message->AddRef("sender_ref", &senderRef);
+
 		// add the folder
 		IconMenuItem* menuItem = new IconMenuItem(B_TRANSLATE(kNewFolderLabel),
 			message, B_DIRECTORY_MIME_TYPE, B_MINI_ICON);
@@ -207,8 +227,11 @@ TemplatesMenu::_BuildTemplateItems(const BString& directory)
 				entry_ref ref;
 				entry.GetRef(&ref);
 
+				entry_ref senderRef;
+				fMessage->FindRef("sender_ref", &senderRef);
 				BMessage *message = new BMessage(fMessage->what);
 				message->AddRef("refs", &ref);
+				message->AddRef("sender_ref", &senderRef);
 				if (entry.IsDirectory())
 					message->AddString("type","new_folder_template");
 				else

--- a/src/templates/TemplatesMenu.h
+++ b/src/templates/TemplatesMenu.h
@@ -41,7 +41,7 @@ public:
 	void					SetViewMode(ViewMode mode, bool enableNewFolder = true);
 	void 					ShowNewFolder(bool show) { fShowNewFolder = show; }
 	void 					EnableNewFolder(bool enable) { fEnableNewFolder = enable; }
-	void					SetSenderEntryRef(const entry_ref* ref);
+	void					SetSender(const void* sender, const entry_ref* ref);
 
 private:
 	bool 					_BuildMenu();

--- a/src/templates/TemplatesMenu.h
+++ b/src/templates/TemplatesMenu.h
@@ -41,6 +41,7 @@ public:
 	void					SetViewMode(ViewMode mode, bool enableNewFolder = true);
 	void 					ShowNewFolder(bool show) { fShowNewFolder = show; }
 	void 					EnableNewFolder(bool enable) { fEnableNewFolder = enable; }
+	void					SetSenderEntryRef(const entry_ref* ref);
 
 private:
 	bool 					_BuildMenu();

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -870,17 +870,17 @@ GenioWindow::MessageReceived(BMessage* message)
 			entry_ref templateRef;
 			if (message->FindRef("template_ref", &templateRef) != B_OK) {
 				LogError("Invalid template %s", templateRef.name);
-				return;
+				break;
 			}
 			entry_ref destRef;
 			if (message->FindRef("directory", &destRef) != B_OK) {
 				LogError("Invalid destination directory %s", destRef.name);
-				return;
+				break;
 			}
 			BString name;
 			if (message->FindString("name", &name) != B_OK) {
 				LogError("Invalid destination name %s", name.String());
-				return;
+				break;
 			}
 			if (TemplateManager::CopyProjectTemplate(&templateRef, &destRef, name.String()) == B_OK) {
 				BPath destPath(&destRef);
@@ -902,7 +902,7 @@ GenioWindow::MessageReceived(BMessage* message)
 			status_t status = message->FindString("type", &type);
 			if (status != B_OK) {
 				LogError("Can't find type!");
-				return;
+				break;
 			}
 
 			if (type == "new_folder")
@@ -1130,7 +1130,8 @@ GenioWindow::MessageReceived(BMessage* message)
 		case MSG_SET_LANGUAGE:
 			_ForwardToSelectedEditor(message);
 			break;
-		case MSG_HELP_GITHUB: {
+		case MSG_HELP_GITHUB:
+		{
 			char *argv[2] = {(char*)"https://github.com/Genio-The-Haiku-IDE/Genio", NULL};
 			be_roster->Launch("text/html", 1, argv);
 			break;
@@ -1140,7 +1141,7 @@ GenioWindow::MessageReceived(BMessage* message)
 			break;
 		case kMsgCapabilitiesUpdated:
 			_UpdateTabChange(fTabManager->SelectedEditor(), "kMsgCapabilitiesUpdated");
-		break;
+			break;
 		default:
 			BWindow::MessageReceived(message);
 			break;

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -3506,6 +3506,7 @@ GenioWindow::_TemplateNewFile(BMessage* message)
 				B_WARNING_ALERT);
 		LogError("Invalid destination directory [%s]", dest.name);
 	} else {
+		// TODO: Fix this
 		//GetProjectBrowser()->SelectNewItemAndScrollDelayed(item, refNew);
 	}
 }
@@ -3514,11 +3515,8 @@ GenioWindow::_TemplateNewFile(BMessage* message)
 void
 GenioWindow::_TemplateNewFolder(BMessage* message)
 {
-	message->PrintToStream();
 	entry_ref ref;
 	message->FindRef("sender_ref", &ref);
-
-	LogError("_TemplateNewFolder: sender_ref: %s", ref.name);
 	entry_ref refNew;
 	status_t status = TemplateManager::CreateNewFolder(&ref, &refNew);
 	if (status != B_OK) {
@@ -3527,15 +3525,9 @@ GenioWindow::_TemplateNewFolder(BMessage* message)
 				B_WARNING_ALERT);
 		LogError("Invalid destination directory [%s]", ref.name);
 	} else {
+		// TODO: Fix this
 		//GetProjectBrowser()->SelectNewItemAndScrollDelayed(item, refNew);
 	}
-	/* else {
-		LogError("Can't find current item");
-		OKAlert(B_TRANSLATE("New folder"),
-				B_TRANSLATE("You can't create a new folder here, "
-							"please select a project or another folder"),
-				B_WARNING_ALERT);
-	}*/
 }
 
 

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -3506,8 +3506,9 @@ GenioWindow::_TemplateNewFile(BMessage* message)
 				B_WARNING_ALERT);
 		LogError("Invalid destination directory [%s]", dest.name);
 	} else {
-		// TODO: Fix this
-		//GetProjectBrowser()->SelectNewItemAndScrollDelayed(item, refNew);
+		ProjectItem* item = nullptr;
+		message->FindPointer("sender", (void**)&item);
+		GetProjectBrowser()->SelectNewItemAndScrollDelayed(item, refNew);
 	}
 }
 
@@ -3525,8 +3526,9 @@ GenioWindow::_TemplateNewFolder(BMessage* message)
 				B_WARNING_ALERT);
 		LogError("Invalid destination directory [%s]", ref.name);
 	} else {
-		// TODO: Fix this
-		//GetProjectBrowser()->SelectNewItemAndScrollDelayed(item, refNew);
+		ProjectItem* item = nullptr;
+		message->FindPointer("sender", (void**)&item);
+		GetProjectBrowser()->SelectNewItemAndScrollDelayed(item, refNew);
 	}
 }
 
@@ -4327,16 +4329,9 @@ GenioWindow::_HandleConfigurationChanged(BMessage* message)
 
 
 void
-GenioWindow::UpdateMenu(const entry_ref* ref)
+GenioWindow::UpdateMenu(const void* sender, const entry_ref* ref)
 {
-	BEntry entry(ref);
-	if (entry.IsFile()) {
-		// if this is a file, get parent directory
-		entry.GetParent(&entry);
-	}
-	entry_ref newRef;
-	entry.GetRef(&newRef);
-	fFileNewMenuItem->SetSenderEntryRef(&newRef);
+	fFileNewMenuItem->SetSender(sender, ref);
 }
 
 

--- a/src/ui/GenioWindow.h
+++ b/src/ui/GenioWindow.h
@@ -121,6 +121,10 @@ private:
 			void				_ProjectFileDelete();
 			void				_ProjectRenameFile();
 
+			void				_TemplateNewFolder(BMessage* message);
+			void				_TemplateNewProject(BMessage* message);
+			void				_TemplateNewFile(BMessage* message);
+
 			void				_ShowDocumentation();
 
 			// Project Folders

--- a/src/ui/GenioWindow.h
+++ b/src/ui/GenioWindow.h
@@ -63,7 +63,7 @@ public:
 	virtual bool				QuitRequested();
 	virtual void				Show();
 
-	void						UpdateMenu(const entry_ref* ref);
+	void						UpdateMenu(const void* sender, const entry_ref* ref);
 	ProjectFolder*				GetActiveProject() const;
 	void						SetActiveProject(ProjectFolder *project);
 	ProjectsFolderBrowser*		GetProjectBrowser() const;

--- a/src/ui/GenioWindow.h
+++ b/src/ui/GenioWindow.h
@@ -63,7 +63,7 @@ public:
 	virtual bool				QuitRequested();
 	virtual void				Show();
 
-	void						UpdateMenu();
+	void						UpdateMenu(const entry_ref* ref);
 	ProjectFolder*				GetActiveProject() const;
 	void						SetActiveProject(ProjectFolder *project);
 	ProjectsFolderBrowser*		GetProjectBrowser() const;

--- a/src/ui/ProjectsFolderBrowser.cpp
+++ b/src/ui/ProjectsFolderBrowser.cpp
@@ -795,20 +795,17 @@ ProjectsFolderBrowser::SelectionChanged()
 	ProjectItem* selected = GetSelectedProjectItem();
 	if (selected != nullptr) {
 		GenioWindow *window = (GenioWindow*)Window();
-		window->UpdateMenu(selected->GetSourceItem()->EntryRef());
-
-		if (fFileNewProjectMenuItem == nullptr)
-			return;
-		// TODO: We are replicating GenioWindow::UpdateMenu here.
-		// merge the two
 		BEntry entry(selected->GetSourceItem()->EntryRef());
 		if (entry.IsFile()) {
-			// Get parent directory
+			// If this is a file, get the parent directory
 			entry.GetParent(&entry);
 		}
 		entry_ref newRef;
 		entry.GetRef(&newRef);
-		fFileNewProjectMenuItem->SetSenderEntryRef(&newRef);
+		window->UpdateMenu(selected, &newRef);
+
+		if (fFileNewProjectMenuItem != nullptr)
+			fFileNewProjectMenuItem->SetSender(selected, &newRef);
 	}
 }
 


### PR DESCRIPTION
Refactor/cleanup:
GenioWindow: split new template/file code into methods.
Refactor TemplateMenu so that GenioWindow doesn't have to call into ProjectsFolderBrowser
