### PR TITLE
Projects pane: Fix opening files' location in Terminal

### DIFF
--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -3752,7 +3752,12 @@ GenioWindow::_OpenTerminalWorkingDirectory()
 	if (selectedProjectItem == nullptr)
 		return B_BAD_VALUE;
 
-	BPath itemPath(selectedProjectItem->GetSourceItem()->EntryRef());
+	BEntry itemEntry(selectedProjectItem->GetSourceItem()->EntryRef());
+	if (!itemEntry.IsDirectory())
+		itemEntry.GetParent(&itemEntry);
+
+	BPath itemPath(&itemEntry);
+
 	const char* argv[] = {
 		"-w",
 		itemPath.Path(),

--- a/src/ui/ProjectsFolderBrowser.cpp
+++ b/src/ui/ProjectsFolderBrowser.cpp
@@ -474,7 +474,7 @@ ProjectsFolderBrowser::_ShowProjectItemPopupMenu(BPoint where)
 
 	BMenuItem* showInTrackerProjectMenuItem = new BMenuItem(B_TRANSLATE("Show in Tracker"),
 		new BMessage(MSG_PROJECT_MENU_SHOW_IN_TRACKER));
-	BMenuItem* openTerminalProjectMenuItem = new BMenuItem(B_TRANSLATE("Open Terminal"),
+	BMenuItem* openTerminalProjectMenuItem = new BMenuItem(B_TRANSLATE("Open in Terminal"),
 		new BMessage(MSG_PROJECT_MENU_OPEN_TERMINAL));
 	showInTrackerProjectMenuItem->SetEnabled(true);
 	openTerminalProjectMenuItem->SetEnabled(true);


### PR DESCRIPTION
* Rename menu item to "Show in Terminal". It's symmetrical to "Show in Tracker". It's more correct, because you don't just open a Terminal somewhere, but in the location of the selected file/folder.

* "Show in Terminal" only worked correctly when invoked in a directory. Invoked on a file, it opened in the project's top folder instead. Terminal's "-w" parameter only accepts folders, not files. No we check if the invoked-on item is a directory. If it isn't use the files parent directory.