### PR TITLE
Settings window: shrink to optimal size

### DIFF
--- a/src/config/ConfigWindow.cpp
+++ b/src/config/ConfigWindow.cpp
@@ -140,15 +140,15 @@ rgb_color GControl<BColorControl, rgb_color>::RetrieveValue()
 
 
 ConfigWindow::ConfigWindow(ConfigManager &configManager)
-    : BWindow(BRect(100, 100, 700, 500), B_TRANSLATE("Settings"), B_TITLED_WINDOW_LOOK, B_MODAL_APP_WINDOW_FEEL,
+    : BWindow(BRect(), B_TRANSLATE("Settings"), B_TITLED_WINDOW_LOOK, B_MODAL_APP_WINDOW_FEEL,
               B_ASYNCHRONOUS_CONTROLS | B_NOT_RESIZABLE | B_NOT_ZOOMABLE | B_AUTO_UPDATE_SIZE_LIMITS | B_CLOSE_ON_ESCAPE),
       fConfigManager(configManager)
 {
 	fShowHidden = modifiers() & B_COMMAND_KEY;
 
-	CenterOnScreen();
 	SetLayout(new BGroupLayout(B_HORIZONTAL));
 	AddChild(_Init());
+	CenterOnScreen();
 }
 
 


### PR DESCRIPTION
Using specific coordinates makes the project's settings window needlessly large. Not using coordinates has the layout management take care of it.
CenterOnScreen() after the building the layout, otherwise the origin of the window gets centered on screen, not the center of the window.