### PR TITLE
Improve/git file removed

### DIFF
--- a/src/ui/GenioWindow.h
+++ b/src/ui/GenioWindow.h
@@ -81,7 +81,13 @@ private:
 			void				_FileCloseAll();
 			bool				_FileRequestSaveList(std::vector<int32>& unsavedIndex);
 			bool				_FileRequestSaveAllModified();
+
 			status_t			_FileOpen(BMessage* msg);
+			status_t			_FileOpenAtStartup(BMessage* msg);
+			status_t			_FileOpenWithPosition(entry_ref* ref, bool openWithPreferred,  int32 be_line, int32 lsp_char);
+			status_t			_SelectEditorToPosition(int32 index, int32 be_line, int32 lsp_char);
+			void				_ApplyEditsToSelectedEditor(BMessage* msg);
+
 			bool				_FileIsSupported(const entry_ref* ref);
 			status_t            _FileOpenWithPreferredApp(const entry_ref* ref);
 			status_t			_FileSave(int32	index);


### PR DESCRIPTION
Some git commands generate a B_ENTRY_REMOVED event in the node monitoring, maybe due to some kind of file replacement.
If often happens with command like git switch or git checkout when a previous version is loaded.
This workaround tries to detech such cases by checking if the file removed exists two times (by reposting the same event to the Looper).
