### PR TITLE
Improve/projectbrowser context menu

### DIFF
--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -912,7 +912,8 @@ GenioWindow::MessageReceived(BMessage* message)
 			break;
 		}
 		case MSG_PROJECT_MENU_CLOSE: {
-			ProjectFolder* project = (ProjectFolder*)message->GetPointer("project", fProjectsFolderBrowser->GetProjectFromSelectedItem());
+			ProjectFolder* project = (ProjectFolder*)message->GetPointer("project",
+									  fProjectsFolderBrowser->GetProjectFromSelectedItem());
 			_ProjectFolderClose(project);
 			break;
 		}
@@ -3589,6 +3590,9 @@ GenioWindow::_ProjectFolderClose(ProjectFolder *project)
 {
 	if (project == nullptr)
 		return;
+
+	printf("Chiudo il progetto: %s\n", project->Name().String());
+
 
 	std::vector<int32> unsavedFiles;
 	for (int32 index = fTabManager->CountTabs() - 1 ; index > -1; index--) {

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -911,9 +911,11 @@ GenioWindow::MessageReceived(BMessage* message)
 			}
 			break;
 		}
-		case MSG_PROJECT_MENU_CLOSE:
-			_ProjectFolderClose(fProjectsFolderBrowser->GetProjectFromSelectedItem());
+		case MSG_PROJECT_MENU_CLOSE: {
+			ProjectFolder* project = (ProjectFolder*)message->GetPointer("project", fProjectsFolderBrowser->GetProjectFromSelectedItem());
+			_ProjectFolderClose(project);
 			break;
+		}
 		case MSG_PROJECT_MENU_DELETE_FILE:
 			_ProjectFileDelete();
 			break;
@@ -926,9 +928,12 @@ GenioWindow::MessageReceived(BMessage* message)
 		case MSG_PROJECT_MENU_OPEN_TERMINAL:
 			_OpenTerminalWorkingDirectory();
 			break;
-		case MSG_PROJECT_MENU_SET_ACTIVE:
-			_ProjectFolderActivate(fProjectsFolderBrowser->GetProjectFromSelectedItem());
+		case MSG_PROJECT_MENU_SET_ACTIVE: {
+			ProjectFolder* project = (ProjectFolder*)message->GetPointer("project", nullptr);
+			if (project != nullptr)
+				_ProjectFolderActivate(project);
 			break;
+		}
 		case MSG_PROJECT_OPEN:
 			fOpenProjectFolderPanel->Show();
 			break;
@@ -945,12 +950,13 @@ GenioWindow::MessageReceived(BMessage* message)
 		}
 		case MSG_PROJECT_SETTINGS:
 		{
-			if (fActiveProject != nullptr) {
-				ConfigWindow* window = new ConfigWindow(fActiveProject->Settings());
+			ProjectFolder* project = (ProjectFolder*)message->GetPointer("project", fActiveProject);
+			if (project != nullptr) {
+				ConfigWindow* window = new ConfigWindow(project->Settings());
 				// TODO: Translate
 				BString windowTitle(B_TRANSLATE("Project:"));
 				windowTitle.Append(" ");
-				windowTitle.Append(fActiveProject->Name());
+				windowTitle.Append(project->Name());
 				window->SetTitle(windowTitle.String());
 				window->Show();
 			}

--- a/src/ui/ProjectBrowser.cpp
+++ b/src/ui/ProjectBrowser.cpp
@@ -432,12 +432,20 @@ ProjectBrowser::_ShowProjectItemPopupMenu(BPoint where)
 	fFileNewProjectMenuItem->SetEnabled(true);
 
 	if (projectItem->GetSourceItem()->Type() == SourceItemType::ProjectFolderItem) {
-		BMenuItem* closeProjectMenuItem = new BMenuItem(B_TRANSLATE("Close project"),
-			new BMessage(MSG_PROJECT_MENU_CLOSE));
-		BMenuItem* setActiveProjectMenuItem = new BMenuItem(B_TRANSLATE("Set active"),
-			new BMessage(MSG_PROJECT_MENU_SET_ACTIVE));
+
+		BMessage* closePrj = new BMessage(MSG_PROJECT_MENU_CLOSE);
+		closePrj->AddPointer("project", (void*)project);
+		BMenuItem* closeProjectMenuItem = new BMenuItem(B_TRANSLATE("Close project"), closePrj);
+
+		BMessage* setActive = new BMessage(MSG_PROJECT_MENU_SET_ACTIVE);
+		setActive->AddPointer("project", (void*)project);
+		BMenuItem* setActiveProjectMenuItem = new BMenuItem(B_TRANSLATE("Set active"), setActive);
+
+		BMessage* projSettings = new BMessage(MSG_PROJECT_SETTINGS);
+		projSettings->AddPointer("project", (void*)project);
 		BMenuItem* projectSettingsMenuItem = new BMenuItem(B_TRANSLATE("Project settings" B_UTF8_ELLIPSIS),
-			new BMessage(MSG_PROJECT_SETTINGS));
+			projSettings);
+
 		projectMenu->AddItem(closeProjectMenuItem);
 		projectMenu->AddItem(setActiveProjectMenuItem);
 		projectMenu->AddItem(projectSettingsMenuItem);
@@ -637,19 +645,6 @@ ProjectBrowser::DetachedFromWindow()
 		Window()->StopWatching(this, MSG_NOTIFY_BUILDING_PHASE);
 		Window()->UnlockLooper();
 	}
-}
-
-// NOTE: this is a workaround to avoid a bug introduced on BListItem on 06-Dec-2023
-// https://github.com/haiku/haiku/commit/6761bf581fd14cac9fd22825fa6baa399263dc83
-// https://dev.haiku-os.org/ticket/18716
-
-void
-ProjectBrowser::MouseUp(BPoint where)
-{
-	if (CountItems() == 0)
-		return;
-
-	BOutlineListView::MouseUp(where);
 }
 
 /* virtual */

--- a/src/ui/ProjectBrowser.cpp
+++ b/src/ui/ProjectBrowser.cpp
@@ -131,7 +131,9 @@ ProjectBrowser::_UpdateNode(BMessage* message)
 			if (item->GetSourceItem()->Type() == SourceItemType::ProjectFolderItem) {
 				if (LockLooper()) {
 					Select(IndexOf(item));
-					Window()->PostMessage(MSG_PROJECT_MENU_CLOSE);
+					BMessage closePrj(MSG_PROJECT_MENU_CLOSE);
+					closePrj.AddPointer("project", item->GetSourceItem());
+					Window()->PostMessage(&closePrj);
 
 					// It seems not possible to track the project folder to the new
 					// location outside of the watched path. So we close the project
@@ -167,7 +169,9 @@ ProjectBrowser::_UpdateNode(BMessage* message)
 					if (item->GetSourceItem()->Type() == SourceItemType::ProjectFolderItem) {
 						if (LockLooper()) {
 							Select(IndexOf(item));
-							Window()->PostMessage(MSG_PROJECT_MENU_CLOSE);
+							BMessage closePrj(MSG_PROJECT_MENU_CLOSE);
+							closePrj.AddPointer("project", item->GetSourceItem());
+							Window()->PostMessage(&closePrj);
 
 							auto alert = new BAlert("ProjectFolderChanged",
 							B_TRANSLATE("The project folder has been renamed. It will be closed and reopened automatically."),
@@ -464,7 +468,6 @@ ProjectBrowser::_ShowProjectItemPopupMenu(BPoint where)
 		if (!project->Active())
 			setActiveProjectMenuItem->SetEnabled(true);
 		if (fIsBuilding || !project->Active()) {
-			projectSettingsMenuItem->SetEnabled(false);
 			buildMenuItem->SetEnabled(false);
 			cleanMenuItem->SetEnabled(false);
 		}

--- a/src/ui/ProjectBrowser.h
+++ b/src/ui/ProjectBrowser.h
@@ -34,7 +34,6 @@ public:
 					 ProjectBrowser();
 	virtual 		~ProjectBrowser();
 
-	virtual	void	MouseUp(BPoint where);
 	virtual void	MouseDown(BPoint where);
 	virtual void	MouseMoved(BPoint point, uint32 transit, const BMessage* message);
 	virtual void	AttachedToWindow();


### PR DESCRIPTION
By adding the ProjectFolder pointer to the context menu items, we could improve the ProjectBroswer isolation and unlock some features like the ability to invoke the project settings panel for any (no active) project.
This PR is a first step.