### PR TITLE
DELETE key to remove a search result

### DIFF
--- a/src/ui/SearchResultPanel.cpp
+++ b/src/ui/SearchResultPanel.cpp
@@ -201,6 +201,18 @@ SearchResultPanel::UpdateSearch(BMessage* msg)
 
 
 void
+SearchResultPanel::KeyDown(const char* bytes, int32 numBytes)
+{
+	if (numBytes > 0 && bytes[0] == B_DELETE) {
+		RangeRow* range = dynamic_cast<RangeRow*>(CurrentSelection());
+		if (range != nullptr)
+			RemoveRow(range);
+	}
+	BColumnListView::KeyDown(bytes, numBytes);
+}
+
+
+void
 SearchResultPanel::_UpdateTabLabel(const char* txt)
 {
 	BString label = SearchResultPanelLabel;

--- a/src/ui/SearchResultPanel.h
+++ b/src/ui/SearchResultPanel.h
@@ -19,8 +19,9 @@ public:
 
 		void StartSearch(BString command, BString projectPath);
 
-		virtual void MessageReceived(BMessage* msg);
+		virtual void	MessageReceived(BMessage* msg);
 		virtual void	AttachedToWindow();
+		virtual void 	KeyDown(const char* bytes, int32 numBytes);
 
 		void	SetTabLabel(BString label);
 


### PR DESCRIPTION
When working with search results, can be convinient to 'remove' the already analized results. Just press the DELETE key to remove the selected one!