### PR TITLE
Feature/outline selection follows caret line

### DIFF
--- a/src/lsp-client/LSPEditorWrapper.cpp
+++ b/src/lsp-client/LSPEditorWrapper.cpp
@@ -918,6 +918,9 @@ LSPEditorWrapper::_DoRecursiveDocumentSymbol(std::vector<DocumentSymbol>& vect, 
 		Range& symbolRange = sym.selectionRange;
 		symbol.AddInt32("start:line", symbolRange.start.line + 1);
 		symbol.AddInt32("start:character", symbolRange.start.character);
+		Range& range = sym.range;
+		symbol.AddInt32("range:start:line", range.start.line + 1);
+		symbol.AddInt32("range:end:line", 	range.end.line + 1);
 		msg.AddMessage("symbol", &symbol);
 	}
 }

--- a/src/ui/Editor.cpp
+++ b/src/ui/Editor.cpp
@@ -739,6 +739,11 @@ Editor::FindPrevious(const BString& search, int flags, bool wrap)
 	return position;
 }
 
+int32
+Editor::GetCurrentLineNumber()
+{
+	return SendMessage(SCI_LINEFROMPOSITION, SendMessage(SCI_GETCURRENTPOS, 0, 0), 0);
+}
 
 int32
 Editor::GetCurrentPosition()

--- a/src/ui/Editor.h
+++ b/src/ui/Editor.h
@@ -159,7 +159,7 @@ public:
 			const 	BString		GetLine(int32 lineNumber);
 			void				InsertLine(BString text, int32 lineNumber);
 			int32				CountLines();
-
+			int32				GetCurrentPosition();
 private:
 
 			int					ReplaceAndFindNext(const BString& selection,
@@ -205,7 +205,6 @@ private:
 			void				OverwriteToggle();
 			BString const		IsOverwriteString();
 			bool				IsSearchSelected(const BString& search, int flags);
-			int32				GetCurrentPosition();
 			void				CommentSelectedLines();
 
 			void				DuplicateCurrentLine();

--- a/src/ui/Editor.h
+++ b/src/ui/Editor.h
@@ -159,7 +159,8 @@ public:
 			const 	BString		GetLine(int32 lineNumber);
 			void				InsertLine(BString text, int32 lineNumber);
 			int32				CountLines();
-			int32				GetCurrentPosition();
+			int32				GetCurrentLineNumber();
+
 private:
 
 			int					ReplaceAndFindNext(const BString& selection,
@@ -217,7 +218,7 @@ private:
 			bool				BookmarkGoToNext();
 			bool				BookmarkGoToPrevious();
 			void				BookmarkToggle(int position);
-
+			int32				GetCurrentPosition();
 			BString	const		_EndOfLineString();
 			void				UpdateStatusBar();
 			void				_ApplyExtensionSettings();

--- a/src/ui/FunctionsOutlineView.cpp
+++ b/src/ui/FunctionsOutlineView.cpp
@@ -364,14 +364,22 @@ FunctionsOutlineView::MessageReceived(BMessage* msg)
 			switch (code) {
 				case MSG_NOTIFY_EDITOR_SYMBOLS_UPDATED:
 				{
+					entry_ref newRef;
+					msg->FindRef("ref", &newRef);
+					Editor* editor = gMainWindow->TabManager()->SelectedEditor();
+					// Got a message from an unselected editor: ignore.
+					if (editor != nullptr && *editor->FileRef() != newRef) {
+						LogTrace("Outline view got a message from an unselected editor. Ignoring...");
+						return;
+					}
+
 					BMessage symbols;
 					if (msg->FindMessage("symbols", &symbols) != B_OK) {
 						debugger("No symbols message");
 						break;
 					}
 					LogTrace("FunctionsOutlineView: Symbols updated message received");
-					entry_ref newRef;
-					msg->FindRef("ref", &newRef);
+
 					_UpdateDocumentSymbols(symbols, &newRef);
 					SelectSymbolByCaretPosition(msg->GetInt32("position", -1));
 					break;
@@ -423,7 +431,7 @@ void
 FunctionsOutlineView::SelectSymbolByCaretPosition(int32 position)
 {
 	BListItem* sym = _RecursiveSymbolByCaretPosition(position, nullptr);
-	if (sym != nullptr) {
+	if (sym != nullptr && sym->IsSelected() == false) {
 		fListView->Select(fListView->IndexOf(sym));
 		fListView->ScrollToSelection();
 	}
@@ -456,13 +464,6 @@ FunctionsOutlineView::_UpdateDocumentSymbols(const BMessage& msg,
 	const entry_ref* newRef)
 {
 	LogTrace("FunctionsOutlineView::_UpdateDocumentSymbol()");
-
-	Editor* editor = gMainWindow->TabManager()->SelectedEditor();
-	// Got a message from an unselected editor: ignore.
-	if (editor != nullptr && *editor->FileRef() != *newRef) {
-		LogTrace("Outline view got a message from an unselected editor. Ignoring...");
-		return;
-	}
 
 	int32 status = msg.GetInt32("status", Editor::STATUS_UNKOWN);
 	switch (status) {

--- a/src/ui/FunctionsOutlineView.cpp
+++ b/src/ui/FunctionsOutlineView.cpp
@@ -373,6 +373,7 @@ FunctionsOutlineView::MessageReceived(BMessage* msg)
 					entry_ref newRef;
 					msg->FindRef("ref", &newRef);
 					_UpdateDocumentSymbols(symbols, &newRef);
+					SelectSymbolByCaretPosition(msg->GetInt32("position", -1));
 					break;
 				}
 				default:
@@ -416,6 +417,38 @@ FunctionsOutlineView::MessageReceived(BMessage* msg)
 			break;
 	}
 }
+
+
+void
+FunctionsOutlineView::SelectSymbolByCaretPosition(int32 position)
+{
+	BListItem* sym = _RecursiveSymbolByCaretPosition(position, nullptr);
+	if (sym != nullptr) {
+		fListView->Select(fListView->IndexOf(sym));
+		fListView->ScrollToSelection();
+	}
+}
+
+
+BListItem*
+FunctionsOutlineView::_RecursiveSymbolByCaretPosition(int32 position, BListItem* parent)
+{
+	for(int32 i=0;i<fListView->CountItemsUnder(parent, true);i++) {
+		SymbolListItem* sym = dynamic_cast<SymbolListItem*>(fListView->ItemUnderAt(parent, true, i));
+		if (sym == nullptr)
+			return nullptr;
+		if (position >= sym->Details().GetInt32("range:start:line", -1) &&
+			position <= sym->Details().GetInt32("range:end:line", -1) ) {
+
+			if (fListView->CountItemsUnder(sym, true) > 0)
+				return _RecursiveSymbolByCaretPosition(position, sym);
+
+			return sym;
+		}
+	}
+	return nullptr;
+}
+
 
 
 void

--- a/src/ui/FunctionsOutlineView.cpp
+++ b/src/ui/FunctionsOutlineView.cpp
@@ -448,8 +448,11 @@ FunctionsOutlineView::_RecursiveSymbolByCaretPosition(int32 position, BListItem*
 		if (position >= sym->Details().GetInt32("range:start:line", -1) &&
 			position <= sym->Details().GetInt32("range:end:line", -1) ) {
 
-			if (fListView->CountItemsUnder(sym, true) > 0)
-				return _RecursiveSymbolByCaretPosition(position, sym);
+			if (fListView->CountItemsUnder(sym, true) > 0 && sym->IsExpanded()) {
+				BListItem* subSym = _RecursiveSymbolByCaretPosition(position, sym);
+				if (subSym != nullptr)
+					return subSym;
+			}
 
 			return sym;
 		}

--- a/src/ui/FunctionsOutlineView.cpp
+++ b/src/ui/FunctionsOutlineView.cpp
@@ -381,7 +381,7 @@ FunctionsOutlineView::MessageReceived(BMessage* msg)
 					LogTrace("FunctionsOutlineView: Symbols updated message received");
 
 					_UpdateDocumentSymbols(symbols, &newRef);
-					SelectSymbolByCaretPosition(msg->GetInt32("position", -1));
+					SelectSymbolByCaretPosition(msg->GetInt32("caret_line", -1));
 					break;
 				}
 				default:

--- a/src/ui/FunctionsOutlineView.h
+++ b/src/ui/FunctionsOutlineView.h
@@ -24,7 +24,10 @@ public:
 	virtual		void	DetachedFromWindow();
 	virtual		void	MessageReceived(BMessage* msg);
 
+	void	SelectSymbolByCaretPosition(int32 position);
+
 private:
+	BListItem*  _RecursiveSymbolByCaretPosition(int32 position, BListItem* parent);
 	void        _UpdateDocumentSymbols(const BMessage& msg,
 									const entry_ref* ref);
 	void	    _RecursiveAddSymbols(BListItem* parent, const BMessage* msg);

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -376,7 +376,7 @@ GenioWindow::MessageReceived(BMessage* message)
 				notifyMessage.AddMessage("symbols", message);
 				notifyMessage.AddRef("ref", &editorRef);
 				if (editor != nullptr)
-					notifyMessage.AddInt32("position", editor->GetCurrentPosition());
+					notifyMessage.AddInt32("caret_line", editor->GetCurrentLineNumber());
 				SendNotices(MSG_NOTIFY_EDITOR_SYMBOLS_UPDATED, &notifyMessage);
 			}
 			break;
@@ -1120,7 +1120,7 @@ GenioWindow::MessageReceived(BMessage* message)
 				editor->GetDocumentSymbols(&symbols);
 				symbolsChanged.AddRef("ref", editor->FileRef());
 				symbolsChanged.AddMessage("symbols", &symbols);
-				symbolsChanged.AddInt32("position", editor->GetCurrentPosition());
+				symbolsChanged.AddInt32("caret_line", editor->GetCurrentLineNumber());
 				SendNotices(MSG_NOTIFY_EDITOR_SYMBOLS_UPDATED, &symbolsChanged);
 
 			}

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -370,10 +370,13 @@ GenioWindow::MessageReceived(BMessage* message)
 		{
 			entry_ref editorRef;
 			if (message->FindRef("ref", &editorRef) == B_OK) {
+				Editor* editor = fTabManager->EditorBy(&editorRef);
 				// add the ref also to the external message
 				BMessage notifyMessage(MSG_NOTIFY_EDITOR_SYMBOLS_UPDATED);
 				notifyMessage.AddMessage("symbols", message);
 				notifyMessage.AddRef("ref", &editorRef);
+				if (editor != nullptr)
+					notifyMessage.AddInt32("position", editor->GetCurrentPosition());
 				SendNotices(MSG_NOTIFY_EDITOR_SYMBOLS_UPDATED, &notifyMessage);
 			}
 			break;
@@ -528,6 +531,8 @@ GenioWindow::MessageReceived(BMessage* message)
 				if (editor == fTabManager->SelectedEditor()) {
 					// Enable Cut,Copy,Paste shortcuts
 					_UpdateSavepointChange(editor, "EDITOR_POSITION_CHANGED");
+					//update the OulineView according to the new position.
+					fFunctionsOutlineView->SelectSymbolByCaretPosition(message->GetInt32("line", -1));
 				}
 			}
 			break;
@@ -1115,6 +1120,7 @@ GenioWindow::MessageReceived(BMessage* message)
 				editor->GetDocumentSymbols(&symbols);
 				symbolsChanged.AddRef("ref", editor->FileRef());
 				symbolsChanged.AddMessage("symbols", &symbols);
+				symbolsChanged.AddInt32("position", editor->GetCurrentPosition());
 				SendNotices(MSG_NOTIFY_EDITOR_SYMBOLS_UPDATED, &symbolsChanged);
 
 			}


### PR DESCRIPTION
See issue #352: when moving the caret line synch the current symbol with the selected one in the ouline view.