### PR TITLE
Remove duplicate handling of TemplatesMenu in ProjectBrowser

### DIFF
--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -1304,6 +1304,13 @@ GenioWindow::TabManager() const
 }
 
 
+::TemplatesMenu*
+GenioWindow::TemplatesMenu()
+{
+	return fFileNewMenuItem;
+}
+
+
 //Freely inspired by the haiku Terminal fullscreen function.
 void
 GenioWindow::_ToogleScreenMode(int32 action)
@@ -3000,9 +3007,7 @@ GenioWindow::_InitMenu()
 
 	BMenu* fileMenu = new BMenu(B_TRANSLATE("File"));
 
-	//ActionManager::AddItem(MSG_FILE_NEW,      fileMenu);
-
-	fileMenu->AddItem(fFileNewMenuItem = new TemplatesMenu(this, B_TRANSLATE("New"),
+	fileMenu->AddItem(fFileNewMenuItem = new ::TemplatesMenu(this, B_TRANSLATE("New"),
 			new BMessage(MSG_FILE_NEW), new BMessage(MSG_SHOW_TEMPLATE_USER_FOLDER),
 			TemplateManager::GetDefaultTemplateDirectory(),
 			TemplateManager::GetUserTemplateDirectory(),

--- a/src/ui/GenioWindow.h
+++ b/src/ui/GenioWindow.h
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "GMessage.h"
-#include "ResourceImport.h"
 
 enum {
 	kProjectsOutline = 0,
@@ -68,9 +67,10 @@ public:
 	void						UpdateMenu(const void* sender, const entry_ref* ref);
 	ProjectFolder*				GetActiveProject() const;
 	void						SetActiveProject(ProjectFolder *project);
-	ProjectBrowser*		GetProjectBrowser() const;
+	ProjectBrowser*				GetProjectBrowser() const;
 
 	EditorTabManager*			TabManager() const;
+	::TemplatesMenu*			TemplatesMenu();
 
 private:
 			Editor*				_AddEditorTab(entry_ref* ref, int32 index, BMessage* addInfo);
@@ -175,7 +175,7 @@ private:
 
 private:
 			BMenuBar*			fMenuBar;
-			TemplatesMenu*		fFileNewMenuItem;
+			::TemplatesMenu*	fFileNewMenuItem;
 
 			BMenu*				fLineEndingsMenu;
 			BMenuItem*			fLineEndingCRLF;

--- a/src/ui/ProjectBrowser.cpp
+++ b/src/ui/ProjectBrowser.cpp
@@ -14,7 +14,7 @@
 #include "ProjectFolder.h"
 #include "ProjectItem.h"
 #include "SwitchBranchMenu.h"
-#include "TemplateManager.h"
+#include "TemplatesMenu.h"
 #include "Utils.h"
 
 #include <Alert.h>
@@ -46,7 +46,6 @@ static BMessageRunner* sAnimationTickRunner;
 ProjectBrowser::ProjectBrowser()
 	:
 	BOutlineListView("ProjectsFolderOutline", B_SINGLE_SELECTION_LIST),
-	fFileNewProjectMenuItem(nullptr),
 	fIsBuilding(false)
 {
 	fGenioWatchingFilter = new GenioWatchingFilter();
@@ -431,14 +430,6 @@ ProjectBrowser::_ShowProjectItemPopupMenu(BPoint where)
 
 	BPopUpMenu* projectMenu = new BPopUpMenu("ProjectMenu", false, false);
 
-	fFileNewProjectMenuItem = new TemplatesMenu(this, B_TRANSLATE("New"),
-		new BMessage(MSG_PROJECT_MENU_NEW_FILE), new BMessage(MSG_SHOW_TEMPLATE_USER_FOLDER),
-		TemplateManager::GetDefaultTemplateDirectory(),
-		TemplateManager::GetUserTemplateDirectory(),
-		TemplatesMenu::SHOW_ALL_VIEW_MODE,	true);
-
-	fFileNewProjectMenuItem->SetEnabled(true);
-
 	if (projectItem->GetSourceItem()->Type() == SourceItemType::ProjectFolderItem) {
 		BMessage* closePrj = new BMessage(MSG_PROJECT_MENU_CLOSE);
 		closePrj->AddPointer("project", (void*)project);
@@ -476,8 +467,9 @@ ProjectBrowser::_ShowProjectItemPopupMenu(BPoint where)
 		}
 	}
 
-	projectMenu->AddItem(fFileNewProjectMenuItem);
-	fFileNewProjectMenuItem->SetViewMode(TemplatesMenu::ViewMode::SHOW_ALL_VIEW_MODE);
+	::TemplatesMenu* templatesMenu = gMainWindow->TemplatesMenu();
+	projectMenu->AddItem(templatesMenu);
+	templatesMenu->SetViewMode(TemplatesMenu::ViewMode::SHOW_ALL_VIEW_MODE);
 	projectMenu->AddSeparatorItem();
 
 	SelectionChanged();
@@ -809,7 +801,6 @@ ProjectBrowser::SelectionChanged()
 {
 	ProjectItem* selected = GetSelectedProjectItem();
 	if (selected != nullptr) {
-		GenioWindow *window = (GenioWindow*)Window();
 		BEntry entry(selected->GetSourceItem()->EntryRef());
 		if (entry.IsFile()) {
 			// If this is a file, get the parent directory
@@ -817,10 +808,7 @@ ProjectBrowser::SelectionChanged()
 		}
 		entry_ref newRef;
 		entry.GetRef(&newRef);
-		window->UpdateMenu(selected, &newRef);
-
-		if (fFileNewProjectMenuItem != nullptr)
-			fFileNewProjectMenuItem->SetSender(selected, &newRef);
+		gMainWindow->UpdateMenu(selected, &newRef);
 	}
 }
 

--- a/src/ui/ProjectBrowser.h
+++ b/src/ui/ProjectBrowser.h
@@ -9,7 +9,6 @@
 #include <OutlineListView.h>
 #include <ObjectList.h>
 
-#include "TemplatesMenu.h"
 
 enum {
 	MSG_PROJECT_MENU_CLOSE				= 'pmcl',
@@ -85,7 +84,6 @@ private:
 	ProjectItem*	_CreateNewProjectItem(ProjectItem* parentItem, BPath path);
 
 private:
-	TemplatesMenu*			fFileNewProjectMenuItem;
 	bool					fIsBuilding;
 	GenioWatchingFilter*	fGenioWatchingFilter;
 


### PR DESCRIPTION
Add a TemplatesMenu() in GenioWindow, and use it in ProjectBrowser to access the menu