### PR TITLE
Rework ProjectBrowser and improved "Drop folder here"

### DIFF
--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -3397,9 +3397,7 @@ GenioWindow::_InitLeftSplit()
 	fProjectsTabView = new BTabView("ProjectsTabview");
 
 	fProjectsFolderBrowser = new ProjectBrowser();
-	fProjectsFolderScroll = new BScrollView(B_TRANSLATE("Projects"),
-		fProjectsFolderBrowser, B_FRAME_EVENTS | B_WILL_DRAW, true, true, B_FANCY_BORDER);
-	fProjectsTabView->AddTab(fProjectsFolderScroll);
+	fProjectsTabView->AddTab(fProjectsFolderBrowser);
 
 	// Source Control
 	fSourceControlPanel = new SourceControlPanel();

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -449,16 +449,6 @@ GenioWindow::MessageReceived(BMessage* message)
 			break;
 		}
 		case 'DATA':
-		{
-			// file / folder drag'n'drop
-			entry_ref ref;
-			if (message->FindRef("refs", &ref) == B_OK &&
-				BEntry(&ref, true).IsDirectory()) {
-				_ProjectFolderOpen(message);
-				break;
-			}
-			// Fallthrough
-		}
 		case B_REFS_RECEIVED:
 			_FileOpen(message);
 			Activate();

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -4559,15 +4559,8 @@ GenioWindow::_UpdateWindowTitle(const char* filePath)
 void
 GenioWindow::_CollapseOrExpandProjects()
 {
-	/*if (gCFG["auto_expand_collapse_projects"]) {
+	if (gCFG["auto_expand_collapse_projects"]) {
 		// Expand active project, collapse other
-		for (int32 i = 0; i < GetProjectBrowser()->CountProjects(); i++) {
-			ProjectFolder* prj = GetProjectBrowser()->ProjectAt(i);
-			ProjectItem* item = GetProjectBrowser()->GetProjectItemForProject(prj);
-			if (prj == fActiveProject)
-				GetProjectBrowser()->Expand(item);
-			else
-				fProjectsFolderBrowser->Collapse(item);
-		}
-	}*/
+		GetProjectBrowser()->ExpandActiveProjects();
+	}
 }

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -4561,7 +4561,7 @@ GenioWindow::_UpdateWindowTitle(const char* filePath)
 void
 GenioWindow::_CollapseOrExpandProjects()
 {
-	if (gCFG["auto_expand_collapse_projects"]) {
+	/*if (gCFG["auto_expand_collapse_projects"]) {
 		// Expand active project, collapse other
 		for (int32 i = 0; i < GetProjectBrowser()->CountProjects(); i++) {
 			ProjectFolder* prj = GetProjectBrowser()->ProjectAt(i);
@@ -4571,5 +4571,5 @@ GenioWindow::_CollapseOrExpandProjects()
 			else
 				fProjectsFolderBrowser->Collapse(item);
 		}
-	}
+	}*/
 }

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -453,7 +453,7 @@ GenioWindow::MessageReceived(BMessage* message)
 			// file / folder drag'n'drop
 			entry_ref ref;
 			if (message->FindRef("refs", &ref) == B_OK &&
-				BEntry(&ref).IsDirectory()) {
+				BEntry(&ref, true).IsDirectory()) {
 				_ProjectFolderOpen(message);
 				break;
 			}
@@ -3852,7 +3852,7 @@ GenioWindow::_ProjectFolderOpen(BMessage *message)
 status_t
 GenioWindow::_ProjectFolderOpen(const entry_ref& ref, bool activate)
 {
-	BEntry dirEntry(&ref);
+	BEntry dirEntry(&ref, true);
 	if (!dirEntry.Exists())
 		return B_NAME_NOT_FOUND;
 
@@ -3892,7 +3892,14 @@ GenioWindow::_ProjectFolderOpen(const entry_ref& ref, bool activate)
 	}
 
 	BMessenger msgr(this);
-	ProjectFolder* newProject = new ProjectFolder(ref, msgr);
+
+	// if the original entry_ref was a symlink we need to resolve the path and pass it
+	// ProjectFolder
+	entry_ref resolved_ref;
+	if (dirEntry.GetRef(&resolved_ref) == B_ERROR)
+		return B_ERROR;
+
+	ProjectFolder* newProject = new ProjectFolder(resolved_ref, msgr);
 	status = newProject->Open();
 	if (status != B_OK) {
 		BString notification;

--- a/src/ui/ProjectBrowser.cpp
+++ b/src/ui/ProjectBrowser.cpp
@@ -443,9 +443,10 @@ ProjectBrowser::MessageReceived(BMessage* message)
 		case kTick:
 		{
 			if (fIsBuilding) {
-				// TODO: Only invalidate the project item
+				// TODO: Only invalidate the project item and
+				// Maybe move inside the ProjectOutlineListView
 				ProjectItem::TickAnimation();
-				Invalidate();
+				fOutlineListView->Invalidate();
 			}
 			break;
 		}

--- a/src/ui/ProjectBrowser.cpp
+++ b/src/ui/ProjectBrowser.cpp
@@ -32,6 +32,7 @@
 #include <OutlineListView.h>
 #include <Path.h>
 #include <PopUpMenu.h>
+#include <ScrollView.h>
 #include <StringList.h>
 #include <Window.h>
 
@@ -69,9 +70,12 @@ ProjectBrowser::ProjectBrowser()
 	fIsBuilding(false)
 {
 	fOutlineListView = new ProjectOutlineListView();
+	BScrollView* scrollView = new BScrollView("scrollview", fOutlineListView,
+		B_FRAME_EVENTS | B_WILL_DRAW, true, true, B_FANCY_BORDER);
+
 	BLayoutBuilder::Group<>(this, B_VERTICAL, B_USE_DEFAULT_SPACING)
 		.AddGroup(B_HORIZONTAL)
-			.Add(fOutlineListView)
+			.Add(scrollView)
 		.End();
 	fGenioWatchingFilter = new GenioWatchingFilter();
 	BPrivate::BPathMonitor::SetWatchingInterface(fGenioWatchingFilter);

--- a/src/ui/ProjectBrowser.cpp
+++ b/src/ui/ProjectBrowser.cpp
@@ -1061,7 +1061,7 @@ ProjectOutlineListView::_ShowProjectItemPopupMenu(BPoint where)
 		setActiveProjectMenuItem->SetEnabled(!project->Active());
 		if (!project->Active())
 			setActiveProjectMenuItem->SetEnabled(true);
-		if (/*fIsBuilding || */!project->Active()) {
+		if (project->IsBuilding() || !project->Active()) {
 			buildMenuItem->SetEnabled(false);
 			cleanMenuItem->SetEnabled(false);
 		}

--- a/src/ui/ProjectBrowser.cpp
+++ b/src/ui/ProjectBrowser.cpp
@@ -414,13 +414,14 @@ ProjectBrowser::MessageReceived(BMessage* message)
 				LogError("(MSG_PROJECT_MENU_OPEN_FILE) Can't find item at index %d", index);
 				return;
 			}
-#if 0
 			if (item->GetSourceItem()->Type() != SourceItemType::FileItem) {
-				ExpandOrCollapse(item, !item->IsExpanded());
-				LogDebug("(MSG_PROJECT_MENU_OPEN_FILE) ExpandOrCollapse(%s)", item->GetSourceItem()->Name().String());
+				if (item->IsExpanded())
+					fOutlineListView->Collapse(item);
+				else
+					fOutlineListView->Expand(item);
+				LogDebug("(MSG_PROJECT_MENU_OPEN_FILE) Expand/Collapse(%s)", item->GetSourceItem()->Name().String());
 				return;
 			}
-#endif
 			BMessage msg(B_REFS_RECEIVED);
 			msg.AddRef("refs", item->GetSourceItem()->EntryRef());
 			msg.AddBool("openWithPreferred", true);

--- a/src/ui/ProjectBrowser.cpp
+++ b/src/ui/ProjectBrowser.cpp
@@ -464,7 +464,7 @@ ProjectBrowser::MessageReceived(BMessage* message)
 					ProjectItem* item = GetProjectItemByPath(fileName);
 					if (item != nullptr) {
 						item->SetOpenedInEditor(open);
-						Invalidate();
+						fOutlineListView->Invalidate();
 					}
 					break;
 				}
@@ -477,7 +477,7 @@ ProjectBrowser::MessageReceived(BMessage* message)
 					ProjectItem* item = GetProjectItemByPath(fileName);
 					if (item != nullptr) {
 						item->SetNeedsSave(needsSave);
-						Invalidate();
+						fOutlineListView->Invalidate();
 					}
 					break;
 				}

--- a/src/ui/ProjectBrowser.cpp
+++ b/src/ui/ProjectBrowser.cpp
@@ -514,6 +514,18 @@ ProjectBrowser::MessageReceived(BMessage* message)
 			}
 			break;
 		}
+		case 'DATA':
+		{
+			// file / folder drag'n'drop
+			entry_ref ref;
+			if (message->FindRef("refs", &ref) == B_OK &&
+				BEntry(&ref, true).IsDirectory()) {
+				BMessage openProjectMessage = *message;
+				openProjectMessage.what = MSG_PROJECT_FOLDER_OPEN;
+				Window()->PostMessage(&openProjectMessage);
+				break;
+			}
+		}
 		default:
 			BView::MessageReceived(message);
 			break;

--- a/src/ui/ProjectBrowser.cpp
+++ b/src/ui/ProjectBrowser.cpp
@@ -83,7 +83,7 @@ class ProjectDropView : public BView {
 public:
 	ProjectDropView()
 		:
-		BView("ProjectDropView", B_WILL_DRAW|B_FULL_UPDATE_ON_RESIZE)
+		BView("ProjectDropView", B_WILL_DRAW|B_FRAME_EVENTS|B_FULL_UPDATE_ON_RESIZE)
 	{
 		BString dropLabel = B_TRANSLATE("Drop folder here");
 		BStringView* stringView = new BStringView("drop", dropLabel.String());
@@ -101,6 +101,11 @@ public:
 		stringView->GetFont(&font);
 		font.SetFace(B_CONDENSED_FACE);
 		stringView->SetFont(&font);
+
+		// TODO: These should not be needed, but without them the
+		// splitview which separates editor from the left pane doesn't move at all
+		SetExplicitMinSize(BSize(0, B_SIZE_UNSET));
+		SetExplicitMaxSize(BSize(B_SIZE_UNLIMITED, B_SIZE_UNSET));
 	}
 	virtual void Draw(BRect updateRect)
 	{
@@ -124,7 +129,7 @@ public:
 // ProjectBrowser
 ProjectBrowser::ProjectBrowser()
 	:
-	BView("ProjectBrowser", B_WILL_DRAW),
+	BView("ProjectBrowser", B_WILL_DRAW|B_FRAME_EVENTS),
 	fIsBuilding(false)
 {
 	fOutlineListView = new ProjectOutlineListView();

--- a/src/ui/ProjectBrowser.cpp
+++ b/src/ui/ProjectBrowser.cpp
@@ -751,7 +751,7 @@ ProjectBrowser::InitRename(ProjectItem *item)
 	fOutlineListView->Select(fOutlineListView->IndexOf(item));
 	fOutlineListView->ScrollToSelection();
 
-	item->InitRename(this, new BMessage(MSG_PROJECT_MENU_DO_RENAME_FILE));
+	item->InitRename(fOutlineListView, new BMessage(MSG_PROJECT_MENU_DO_RENAME_FILE));
 	Invalidate();
 }
 

--- a/src/ui/ProjectBrowser.cpp
+++ b/src/ui/ProjectBrowser.cpp
@@ -61,6 +61,7 @@ public:
 
 	virtual void	SelectionChanged();
 
+	ProjectItem*	ProjectItemAt(int32 index) const;
 	ProjectItem*	GetSelectedProjectItem() const;
 
 	static int 		CompareProjectItems(const BListItem* a, const BListItem* b);
@@ -402,17 +403,18 @@ ProjectBrowser::MessageReceived(BMessage* message)
 				LogError("(MSG_PROJECT_MENU_OPEN_FILE) Can't find index!");
 				return;
 			}
-			ProjectItem* item = dynamic_cast<ProjectItem*>(fOutlineListView->ItemAt(index));
+			ProjectItem* item = fOutlineListView->ProjectItemAt(index);
 			if (item == nullptr) {
 				LogError("(MSG_PROJECT_MENU_OPEN_FILE) Can't find item at index %d", index);
 				return;
 			}
-			/*if (item->GetSourceItem()->Type() != SourceItemType::FileItem) {
+#if 0
+			if (item->GetSourceItem()->Type() != SourceItemType::FileItem) {
 				ExpandOrCollapse(item, !item->IsExpanded());
 				LogDebug("(MSG_PROJECT_MENU_OPEN_FILE) ExpandOrCollapse(%s)", item->GetSourceItem()->Name().String());
 				return;
-			}*/
-
+			}
+#endif
 			BMessage msg(B_REFS_RECEIVED);
 			msg.AddRef("refs", item->GetSourceItem()->EntryRef());
 			msg.AddBool("openWithPreferred", true);
@@ -877,7 +879,7 @@ ProjectOutlineListView::MouseMoved(BPoint point, uint32 transit, const BMessage*
 	if ((transit == B_ENTERED_VIEW) || (transit == B_INSIDE_VIEW)) {
 		auto index = IndexOf(point);
 		if (index >= 0) {
-			ProjectItem *item = reinterpret_cast<ProjectItem*>(ItemAt(index));
+			ProjectItem *item = ProjectItemAt(index);
 			if (item->HasToolTip()) {
 				SetToolTip(item->GetToolTipText());
 			} else {
@@ -937,13 +939,20 @@ ProjectOutlineListView::SelectionChanged()
 
 
 ProjectItem*
+ProjectOutlineListView::ProjectItemAt(int32 index) const
+{
+	return static_cast<ProjectItem*>(ItemAt(index));
+}
+
+
+ProjectItem*
 ProjectOutlineListView::GetSelectedProjectItem() const
 {
 	const int32 selection = CurrentSelection();
 	if (selection < 0)
 		return nullptr;
 
-	return dynamic_cast<ProjectItem*>(ItemAt(selection));
+	return ProjectItemAt(selection);
 }
 
 

--- a/src/ui/ProjectBrowser.cpp
+++ b/src/ui/ProjectBrowser.cpp
@@ -15,6 +15,7 @@
 #include "ProjectItem.h"
 #include "SwitchBranchMenu.h"
 #include "TemplateManager.h"
+#include "TemplatesMenu.h"
 #include "Utils.h"
 
 #include <Alert.h>
@@ -693,6 +694,20 @@ ProjectBrowser::ProjectFolderPopulate(ProjectFolder* project)
 			B_WATCH_RECURSIVELY, BMessenger(this));
 	if (status != B_OK)
 		LogErrorF("Can't StartWatching! path [%s] error[%s]", projectPath.String(), ::strerror(status));
+}
+
+
+void
+ProjectBrowser::ExpandActiveProjects()
+{
+	for (int32 i = 0; i < CountProjects(); i++) {
+		ProjectFolder* prj = ProjectAt(i);
+		ProjectItem* item = GetProjectItemForProject(prj);
+		if (prj->Active())
+			fOutlineListView->Expand(item);
+		else
+			fOutlineListView->Collapse(item);
+	}
 }
 
 

--- a/src/ui/ProjectBrowser.cpp
+++ b/src/ui/ProjectBrowser.cpp
@@ -1101,5 +1101,10 @@ ProjectOutlineListView::_ShowProjectItemPopupMenu(BPoint where)
 	ActionManager::AddItem(MSG_PROJECT_MENU_OPEN_TERMINAL, projectMenu, refMessage2);
 
 	projectMenu->SetTargetForItems(Window());
-	projectMenu->Go(ConvertToScreen(where), true);
+
+	// Open menu slightly off wrt the click, so it doesn't open right under the mouse
+	BPoint menuPoint = ConvertToScreen(where);
+	menuPoint.x += 1;
+	menuPoint.y += 1;
+	projectMenu->Go(menuPoint, true);
 }

--- a/src/ui/ProjectBrowser.h
+++ b/src/ui/ProjectBrowser.h
@@ -2,13 +2,12 @@
  * Copyright 2023, Andrea Anzani <andrea.anzani@gmail.com>
  * All rights reserved. Distributed under the terms of the MIT license.
  */
-#ifndef ProjectsFolderBrowser_H
-#define ProjectsFolderBrowser_H
+#pragma once
 
+#include <View.h>
 
 #include <ObjectList.h>
 
-#include "TemplatesMenu.h"
 
 enum {
 	MSG_PROJECT_MENU_CLOSE				= 'pmcl',
@@ -48,6 +47,8 @@ public:
 
 	void			ProjectFolderPopulate(ProjectFolder* project);
 	void			ProjectFolderDepopulate(ProjectFolder* project);
+
+	void			ExpandActiveProjects();
 
 	void			InitRename(ProjectItem *item);
 
@@ -89,6 +90,3 @@ private:
 	BObjectList<ProjectFolder>	fProjectList;
 	BObjectList<ProjectItem>	fProjectProjectItemList;
 };
-
-
-#endif // ProjectsFolderBrowser_H

--- a/src/ui/ProjectBrowser.h
+++ b/src/ui/ProjectBrowser.h
@@ -82,7 +82,6 @@ private:
 
 private:
 	ProjectOutlineListView*	fOutlineListView;
-	TemplatesMenu*			fFileNewProjectMenuItem;
 	bool					fIsBuilding;
 	GenioWatchingFilter*	fGenioWatchingFilter;
 

--- a/src/ui/ProjectBrowser.h
+++ b/src/ui/ProjectBrowser.h
@@ -6,7 +6,6 @@
 #define ProjectsFolderBrowser_H
 
 
-#include <OutlineListView.h>
 #include <ObjectList.h>
 
 #include "TemplatesMenu.h"
@@ -25,17 +24,16 @@ enum {
 	MSG_BROWSER_SELECT_ITEM				= 'sele'
 };
 
+class ProjectOutlineListView;
 class ProjectFolder;
 class ProjectItem;
 class GenioWatchingFilter;
 
-class ProjectBrowser : public BOutlineListView {
+class ProjectBrowser : public BView {
 public:
 					 ProjectBrowser();
 	virtual 		~ProjectBrowser();
 
-	virtual void	MouseDown(BPoint where);
-	virtual void	MouseMoved(BPoint point, uint32 transit, const BMessage* message);
 	virtual void	AttachedToWindow();
 	virtual void	DetachedFromWindow();
 	virtual void	MessageReceived(BMessage* message);
@@ -50,8 +48,6 @@ public:
 
 	void			ProjectFolderPopulate(ProjectFolder* project);
 	void			ProjectFolderDepopulate(ProjectFolder* project);
-
-	virtual void	SelectionChanged();
 
 	void			InitRename(ProjectItem *item);
 
@@ -76,7 +72,7 @@ private:
 
 	void			_ShowProjectItemPopupMenu(BPoint where);
 
-	static	int		_CompareProjectItems(const BListItem* a, const BListItem* b);
+//	static	int		_CompareProjectItems(const BListItem* a, const BListItem* b);
 
 	void			_UpdateNode(BMessage *message);
 
@@ -85,6 +81,7 @@ private:
 	ProjectItem*	_CreateNewProjectItem(ProjectItem* parentItem, BPath path);
 
 private:
+	ProjectOutlineListView*	fOutlineListView;
 	TemplatesMenu*			fFileNewProjectMenuItem;
 	bool					fIsBuilding;
 	GenioWatchingFilter*	fGenioWatchingFilter;


### PR DESCRIPTION
Reworked ProjectBrowser.

Instead of inheriting from BOutlineListView, now it uses one (albeit a custom one).
This allowed using a card layout which hides the ListView when there are no projects.
 