### PR TITLE
Add the option to set an arbitrary path within the project folder and…

### DIFF
--- a/src/project/ProjectFolder.cpp
+++ b/src/project/ProjectFolder.cpp
@@ -260,6 +260,20 @@ ProjectFolder::GuessBuildCommand()
 
 
 void
+ProjectFolder::SetBuildFilePath(BString const& path)
+{
+	(*fSettings)["build_file_path"] = path;
+}
+
+
+BString const
+ProjectFolder::GetBuildFilePath() const
+{
+	return (*fSettings)["build_file_path"];
+}
+
+
+void
 ProjectFolder::SetBuildCommand(BString const& command, BuildMode mode)
 {
 	if (mode == BuildMode::ReleaseMode)
@@ -397,6 +411,8 @@ ProjectFolder::_PrepareSettings()
 	BString build(B_TRANSLATE("Build"));
 	fSettings->AddConfig(build, "build_mode",
 		B_TRANSLATE("Build mode:"), int32(BuildMode::ReleaseMode), &buildModes);
+	fSettings->AddConfig(build, "build_file_path",
+		B_TRANSLATE("Build file path:"), "");
 
 	BString release(B_TRANSLATE("Release"));
 	BString buildRelease(build);

--- a/src/project/ProjectFolder.h
+++ b/src/project/ProjectFolder.h
@@ -80,6 +80,9 @@ public:
 	bool						IsBuilding() const { return fIsBuilding; }
 	void						SetBuildingState(bool isBuilding) { fIsBuilding = isBuilding; }
 
+	void						SetBuildFilePath(BString const& path);
+	BString const				GetBuildFilePath() const;
+
 	void						GuessBuildCommand();
 
 	void						SetCleanCommand(BString const& command, BuildMode mode);

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -1626,6 +1626,9 @@ GenioWindow::_BuildProject()
 
 	// Go to appropriate directory
 	chdir(fActiveProject->Path());
+	auto buildPath = fActiveProject->GetBuildFilePath();
+	if (!buildPath.IsEmpty())
+		chdir(buildPath);
 
 	return fBuildLogView->RunCommand(&message);
 }
@@ -1678,6 +1681,9 @@ GenioWindow::_CleanProject()
 
 	// Go to appropriate directory
 	chdir(fActiveProject->Path());
+	auto buildPath = fActiveProject->GetBuildFilePath();
+	if (!buildPath.IsEmpty())
+		chdir(buildPath);
 
 	return fBuildLogView->RunCommand(&message);
 }


### PR DESCRIPTION
… build from there. This should fix also the problem where the build log could not detect the file link correctly if the build file is not located in the root of the projet