### PR TITLE
Improve/settings notification

### DIFF
--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -4228,6 +4228,7 @@ GenioWindow::_UpdateProjectMenuItemsState(bool enable)
 		ActionManager::SetEnabled(MSG_PROJECT_SETTINGS, false);
 		fFileNewMenuItem->SetViewMode(TemplatesMenu::ViewMode::SHOW_ALL_VIEW_MODE);
 	}
+
 	// TODO: without this, the "Git" menuitem is drawn deactivated on start
 	// but gets drawn correctly once we click on it
 	fMenuBar->Invalidate();
@@ -4536,7 +4537,8 @@ GenioWindow::_HandleProjectConfigurationChanged(BMessage* message)
 		return;
 
 	bool isActive = project == GetActiveProject();
-	if (isActive || GetActiveProject() == nullptr) {
+	const BString context = message->GetString("context");
+	if (context == "load_from_file_end" && (isActive || GetActiveProject() == nullptr)) {
 		// Update debug/release
 		_UpdateProjectMenuItemsState(isActive);
 	}


### PR DESCRIPTION
ConfigManager: add "context" also when loading settings.

GenioWindow: only call UpdateProjectMenuItemsState once using the newly introduced context.

