### PR TITLE
Refactor/branch changes notification

### DIFF
--- a/src/git/GitRepository.cpp
+++ b/src/git/GitRepository.cpp
@@ -369,8 +369,9 @@ namespace Genio::Git {
 		return fileStatuses;
 	}
 
+	/* static */
 	BLooper*
-	GitRepository::Looper() const
+	GitRepository::Looper()
 	{
 		// TODO: using the BApplication looper for now
 		return be_app;

--- a/src/git/GitRepository.h
+++ b/src/git/GitRepository.h
@@ -18,6 +18,7 @@
 #include "Log.h"
 
 
+class BLooper;
 class BPath;
 
 namespace Genio::Git {
@@ -114,9 +115,12 @@ namespace Genio::Git {
 
 		RepoFiles						GetFiles() const;
 
+		BLooper*						Looper() const;
+
 	private:
 		git_repository 					*fRepository;
 		BString							fRepositoryPath;
+		mutable BString					fCurrentBranch;
 		bool							fInitialized;
 
 		void							_Open();
@@ -133,5 +137,7 @@ namespace Genio::Git {
 		int 							_FastForward(const git_oid *target_oid, int is_unborn);
 		int								_CreateCommit(git_index* index, const char* message);
 		void							_CreateInitialCommit();
+
+		void							_NotifyBranchChanged() const;
 	};
 }

--- a/src/git/GitRepository.h
+++ b/src/git/GitRepository.h
@@ -115,7 +115,7 @@ namespace Genio::Git {
 
 		RepoFiles						GetFiles() const;
 
-		BLooper*						Looper() const;
+		static BLooper*					Looper();
 
 	private:
 		git_repository 					*fRepository;

--- a/src/git/SourceControlPanel.cpp
+++ b/src/git/SourceControlPanel.cpp
@@ -682,18 +682,7 @@ SourceControlPanel::_SwitchBranch(BMessage *message)
 void
 SourceControlPanel::_SetCurrentBranch(const ProjectFolder* project, const BString& branch)
 {
-	if (branch == fCurrentBranch)
-		return;
-
 	fCurrentBranch = branch;
-
-	BMessage message(MSG_NOTIFY_GIT_BRANCH_CHANGED);
-	message.AddString("current_branch", branch);
-	if (project != nullptr) {
-		message.AddString("project_name", project->Name());
-		message.AddString("project_path", project->Path());
-	}
-	SendNotices(MSG_NOTIFY_GIT_BRANCH_CHANGED, &message);
 }
 
 

--- a/src/project/ProjectItem.cpp
+++ b/src/project/ProjectItem.cpp
@@ -291,20 +291,6 @@ ProjectTitleItem::DrawItem(BView* owner, BRect bounds, bool complete)
 	circleRect.right = circleRect.left + owner->StringWidth(Text()) + 5;
 	owner->FillRoundRect(circleRect, 9, 10);
 
-	// TODO: this part is quite computationally intensive
-	// and shoud be moved away from the DrawItem.
-	BString branchName;
-	try {
-		if (projectFolder->GetRepository()) {
-			branchName = projectFolder->GetRepository()->GetCurrentBranch();
-			BString extraText;
-			extraText << "  [" << branchName << "]";
-			SetExtraText(extraText);
-		}
-	} catch (const Genio::Git::GitException &ex) {
-		LogDebug("ProjectTitleItem::DrawItem(): %s", ex.Message().String());
-	}
-
 	owner->SetHighColor(TextColorByLuminance(projectFolder->Color()));
 	DrawText(owner, Text(), ExtraText(), textPoint);
 
@@ -322,7 +308,7 @@ ProjectTitleItem::DrawItem(BView* owner, BRect bounds, bool complete)
 	toolTipText.SetToFormat("%s: %s\n%s: %s\n%s: %s",
 								B_TRANSLATE("Project"), projectName.String(),
 								B_TRANSLATE("Path"), projectPath.String(),
-								B_TRANSLATE("Current branch"), branchName.String());
+								B_TRANSLATE("Current branch"), ExtraText());
 	SetToolTipText(toolTipText);
 }
 

--- a/src/project/ProjectItem.cpp
+++ b/src/project/ProjectItem.cpp
@@ -18,8 +18,8 @@
 #include <TranslationUtils.h>
 #include <Window.h>
 
-#include "GitRepository.h"
 #include "IconCache.h"
+#include "Log.h"
 #include "ProjectFolder.h"
 #include "Utils.h"
 

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -227,6 +227,7 @@ GenioWindow::Show()
 		ActionManager::SetEnabled(MSG_JUMP_GO_BACK, false);
 		ActionManager::SetEnabled(MSG_JUMP_GO_FORWARD, false);
 
+		GitRepository::Looper()->StartWatching(this, MSG_NOTIFY_GIT_BRANCH_CHANGED);
 		be_app->StartWatching(this, gCFG.UpdateMessageWhat());
 		be_app->StartWatching(this, kMsgProjectSettingsUpdated);
 		UnlockLooper();
@@ -3324,8 +3325,6 @@ GenioWindow::_InitTabViews()
 	//LEFT
 	fProjectsFolderBrowser = new ProjectBrowser();
 	fSourceControlPanel = new SourceControlPanel();
-	// TODO: See GitRepository::Looper()
-	be_app->StartWatching(this, MSG_NOTIFY_GIT_BRANCH_CHANGED);
 	fPanelTabManager->AddPanelByConfig(fProjectsFolderBrowser, kTabProjectBrowser);
 	fPanelTabManager->AddPanelByConfig(fSourceControlPanel, kTabSourceControl);
 

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -3321,7 +3321,6 @@ GenioWindow::_InitTabViews()
 	fPanelTabManager->AddPanelByConfig(fSearchResultTab, kTabSearchResult);
 	fPanelTabManager->AddPanelByConfig(new TerminalTab(), kTabTerminal);
 
-
 	//LEFT
 	fProjectsFolderBrowser = new ProjectBrowser();
 	fSourceControlPanel = new SourceControlPanel();

--- a/src/ui/GenioWindow.cpp
+++ b/src/ui/GenioWindow.cpp
@@ -3325,7 +3325,8 @@ GenioWindow::_InitTabViews()
 	//LEFT
 	fProjectsFolderBrowser = new ProjectBrowser();
 	fSourceControlPanel = new SourceControlPanel();
-	fSourceControlPanel->StartWatching(this, MSG_NOTIFY_GIT_BRANCH_CHANGED);
+	// TODO: See GitRepository::Looper()
+	be_app->StartWatching(this, MSG_NOTIFY_GIT_BRANCH_CHANGED);
 	fPanelTabManager->AddPanelByConfig(fProjectsFolderBrowser, kTabProjectBrowser);
 	fPanelTabManager->AddPanelByConfig(fSourceControlPanel, kTabSourceControl);
 

--- a/src/ui/GenioWindowMessages.h
+++ b/src/ui/GenioWindowMessages.h
@@ -185,7 +185,6 @@ enum {
 
 	// git / source control
 	MSG_NOTIFY_GIT_BRANCH_CHANGED = 'gbch'			// current_branch (string)
-													// project_name (string)
 													// project_path (string)
 };
 

--- a/src/ui/ProjectBrowser.cpp
+++ b/src/ui/ProjectBrowser.cpp
@@ -492,6 +492,21 @@ ProjectBrowser::MessageReceived(BMessage* message)
 					}
 					break;
 				}
+				case MSG_NOTIFY_GIT_BRANCH_CHANGED:
+				{
+					const BString projectPath = message->GetString("project_path");
+					ProjectItem* item = GetProjectItemByPath(projectPath);
+					if (item != nullptr) {
+						BString branch = message->GetString("current_branch");
+						BString text;
+						if (!branch.IsEmpty()) {
+							text << " [" << branch << "]";
+						}
+						item->SetExtraText(text);
+						fOutlineListView->Invalidate();
+					}
+					break;
+				}
 				case kMsgProjectSettingsUpdated:
 				{
 					const ProjectFolder* project
@@ -698,6 +713,7 @@ ProjectBrowser::AttachedToWindow()
 		Window()->StartWatching(this, MSG_NOTIFY_BUILDING_PHASE);
 		Window()->StartWatching(this, MSG_NOTIFY_FILE_SAVE_STATUS_CHANGED);
 		Window()->StartWatching(this, MSG_NOTIFY_PROJECT_SET_ACTIVE);
+		be_app->StartWatching(this, MSG_NOTIFY_GIT_BRANCH_CHANGED);
 		be_app->StartWatching(this, kMsgProjectSettingsUpdated);
 		Window()->UnlockLooper();
 	}
@@ -729,6 +745,7 @@ ProjectBrowser::DetachedFromWindow()
 		Window()->StopWatching(this, MSG_NOTIFY_FILE_SAVE_STATUS_CHANGED);
 		Window()->StopWatching(this, MSG_NOTIFY_BUILDING_PHASE);
 		Window()->StopWatching(this, MSG_NOTIFY_PROJECT_SET_ACTIVE);
+		be_app->StopWatching(this, MSG_NOTIFY_GIT_BRANCH_CHANGED);
 		be_app->StopWatching(this, kMsgProjectSettingsUpdated);
 		Window()->UnlockLooper();
 	}

--- a/src/ui/ProjectBrowser.cpp
+++ b/src/ui/ProjectBrowser.cpp
@@ -423,7 +423,7 @@ ProjectBrowser::MessageReceived(BMessage* message)
 		case kTick:
 		{
 			ProjectTitleItem::TickAnimation();
-			for(ProjectItem* titleItem: fProjectProjectItemList) {
+			for (ProjectItem* titleItem: fProjectProjectItemList) {
 				if (titleItem->GetSourceItem()->GetProjectFolder()->IsBuilding()) {
 					int32 itemIndex = fOutlineListView->IndexOf(titleItem);
 					fOutlineListView->InvalidateItem(itemIndex);
@@ -453,7 +453,7 @@ ProjectBrowser::MessageReceived(BMessage* message)
 					ProjectItem* item = GetProjectItemByPath(fileName);
 					if (item != nullptr) {
 						item->SetOpenedInEditor(open);
-						fOutlineListView->Invalidate();
+						fOutlineListView->InvalidateItem(fOutlineListView->IndexOf(item));
 					}
 					break;
 				}
@@ -476,7 +476,7 @@ ProjectBrowser::MessageReceived(BMessage* message)
 					ProjectItem* item = GetProjectItemByPath(fileName);
 					if (item != nullptr) {
 						item->SetNeedsSave(needsSave);
-						fOutlineListView->Invalidate();
+						fOutlineListView->InvalidateItem(fOutlineListView->IndexOf(item));
 					}
 					break;
 				}
@@ -503,7 +503,7 @@ ProjectBrowser::MessageReceived(BMessage* message)
 							text << " [" << branch << "]";
 						}
 						item->SetExtraText(text);
-						fOutlineListView->Invalidate();
+						fOutlineListView->InvalidateItem(fOutlineListView->IndexOf(item));
 					}
 					break;
 				}


### PR DESCRIPTION
Move branch change notification to GitRepository

This change introduces a behavioural change: on the project browser, the current branch is only shown for the active project on startup, since the active project is the only one for which we retrieve the repository informations.
The other projects's repository information is only retrieved "on demand".

We could change that, although IMHO it makes more sense this way.