### PR TITLE
Add XHTML as supported MIME type

### DIFF
--- a/Genio.rdef
+++ b/Genio.rdef
@@ -21,6 +21,7 @@ resource file_types message {
 	"types" = "text/x-source-code",
 	"types" = "text/x-makefile",
 	"types" = "text/x-jamfile",
+	"types" = "application/xhtml+xml",
 	"types" = "application/x-vnd.Be-directory"
 };
 


### PR DESCRIPTION
Docs are often XHTML files. Contrary to HTML, that MIME isn't under the supertype "text/", but is "application/xhtml+xml".